### PR TITLE
Fix duplicate researcher URLs and add extraction tracking

### DIFF
--- a/database.py
+++ b/database.py
@@ -136,6 +136,8 @@ class Database:
                     content_hash VARCHAR(64),
                     timestamp DATETIME,
                     researcher_id INT,
+                    extracted_at DATETIME,
+                    extracted_hash VARCHAR(64),
                     UNIQUE KEY uq_url_id (url_id),
                     INDEX idx_url_id_ts (url_id, timestamp),
                     FOREIGN KEY (researcher_id) REFERENCES researchers(id),
@@ -214,6 +216,66 @@ class Database:
             )
 
     @staticmethod
+    def apply_schema_migrations():
+        """
+        Apply schema migrations to existing tables.
+        Safe to run on every startup — each step is idempotent.
+        """
+        # 1. Remove duplicate researcher_urls rows, keeping the lowest ID
+        Database.execute_query("""
+            DELETE r1 FROM researcher_urls r1
+            JOIN researcher_urls r2
+              ON r1.researcher_id = r2.researcher_id
+              AND r1.url = r2.url
+              AND r1.id > r2.id
+        """)
+
+        # 2. Add UNIQUE KEY to researcher_urls if not present
+        result = Database.fetch_one("""
+            SELECT COUNT(*)
+            FROM information_schema.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'researcher_urls'
+              AND CONSTRAINT_NAME = 'uq_researcher_url'
+        """)
+        if result and result[0] == 0:
+            Database.execute_query("""
+                ALTER TABLE researcher_urls
+                  ADD UNIQUE KEY uq_researcher_url (researcher_id, url(500))
+            """)
+            logging.info("Migration: added UNIQUE KEY uq_researcher_url to researcher_urls")
+
+        # 3. Add extracted_at column to html_content if not present
+        result = Database.fetch_one("""
+            SELECT COUNT(*)
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'html_content'
+              AND COLUMN_NAME = 'extracted_at'
+        """)
+        if result and result[0] == 0:
+            Database.execute_query("""
+                ALTER TABLE html_content ADD COLUMN extracted_at DATETIME
+            """)
+            logging.info("Migration: added extracted_at column to html_content")
+
+        # 4. Add extracted_hash column to html_content if not present
+        result = Database.fetch_one("""
+            SELECT COUNT(*)
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'html_content'
+              AND COLUMN_NAME = 'extracted_hash'
+        """)
+        if result and result[0] == 0:
+            Database.execute_query("""
+                ALTER TABLE html_content ADD COLUMN extracted_hash VARCHAR(64)
+            """)
+            logging.info("Migration: added extracted_hash column to html_content")
+
+        logging.info("Schema migrations applied successfully")
+
+    @staticmethod
     def get_researcher_id(first_name, last_name, position=None, affiliation=None):
         """
         Get the researcher ID based on the first name and last name.
@@ -274,4 +336,5 @@ class Database:
 if __name__ == "__main__":
     Database.create_database()  # Create the database before creating tables
     Database.create_tables()
+    Database.apply_schema_migrations()
     Database.import_data_from_file('urls.csv')

--- a/html_fetcher.py
+++ b/html_fetcher.py
@@ -323,6 +323,38 @@ class HTMLFetcher:
         return result[0] if result else None
 
     @staticmethod
+    def needs_extraction(url_id):
+        """
+        Return True if LLM extraction is needed for this URL.
+        Extraction is needed when content_hash differs from extracted_hash
+        (content changed since last extraction, or never extracted).
+        Returns False if no HTML has been downloaded yet.
+        """
+        query = """
+            SELECT content_hash, extracted_hash
+            FROM html_content
+            WHERE url_id = %s
+        """
+        result = Database.fetch_one(query, (url_id,))
+        if not result:
+            return False  # No content downloaded yet — nothing to extract
+        content_hash, extracted_hash = result
+        return content_hash != extracted_hash
+
+    @staticmethod
+    def mark_extracted(url_id):
+        """
+        Record that extraction has been run on the current content by setting
+        extracted_hash = content_hash and extracted_at = now.
+        """
+        query = """
+            UPDATE html_content
+            SET extracted_at = %s, extracted_hash = content_hash
+            WHERE url_id = %s
+        """
+        Database.execute_query(query, (datetime.utcnow(), url_id))
+
+    @staticmethod
     def get_previous_text(url_id):
         """Retrieve the previous text content for a given URL ID (before current upsert).
         With upsert, there's only one row per url_id, so this returns the current stored

--- a/main.py
+++ b/main.py
@@ -23,7 +23,10 @@ def extract_data_from_htmls():
     """Extract publication data from downloaded HTML content."""
     researcher_urls = Researcher.get_all_researcher_urls()
     for id, researcher_id, url, page_type in researcher_urls:
-        if page_type in ["PUB", "WP","RES"]:
+        if page_type in ["PUB", "WP", "RES"]:
+            if not HTMLFetcher.needs_extraction(id):
+                logging.info(f"Skipping extraction for URL ID: {id}, URL: {url} (content unchanged since last extraction)")
+                continue
             logging.info(f"Extracting data from HTML for URL ID: {id}, URL: {url}, Page Type: {page_type}")
             html_content = HTMLFetcher.get_latest_text(id)
             if html_content:
@@ -32,6 +35,7 @@ def extract_data_from_htmls():
                     Publication.save_publications(url, extracted_publications)
                 else:
                     logging.warning(f"No publications extracted for URL ID: {id}, URL: {url}")
+                HTMLFetcher.mark_extracted(id)
             else:
                 logging.error(f"No HTML content found for URL ID: {id}, URL: {url}")
         else:
@@ -39,6 +43,8 @@ def extract_data_from_htmls():
 
 def main():
     """Main function to handle user input and execute the appropriate actions."""
+    Database.apply_schema_migrations()
+
     actions = {
         '1': ('Import data from a file', import_data),
         '2': ('Download HTML content', download_htmls),


### PR DESCRIPTION
Fixes two bugs that caused researchers to be reprocessed multiple times per run, wasting LLM API calls.

## Bug 1: Missing UNIQUE KEY on `researcher_urls`
Adds an idempotent `apply_schema_migrations()` method that deduplicates existing rows and adds the missing `UNIQUE KEY uq_researcher_url` constraint.

## Bug 2: No extraction skip logic
Adds `extracted_at` and `extracted_hash` columns to `html_content`. `extract_data_from_htmls()` now skips LLM calls when content is unchanged since last extraction.

Closes #11

Generated with [Claude Code](https://claude.ai/code)