### PR TITLE
feat: researcher pagination, ?since= feed filter, bio column, filter params

### DIFF
--- a/api.py
+++ b/api.py
@@ -266,6 +266,7 @@ async def list_publications(
     year: str | None = Query(None),
     researcher_id: int | None = Query(None),
     status: str | None = Query(None),
+    since: str | None = Query(None),
 ):
     valid_statuses = {"published", "accepted", "revise_and_resubmit", "reject_and_resubmit"}
     if status and status not in valid_statuses:
@@ -283,6 +284,13 @@ async def list_publications(
     if status:
         conditions.append("p.status = %s")
         params.append(status)
+    if since:
+        try:
+            since_dt = datetime.fromisoformat(since.rstrip("Z"))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid ?since= value; expected ISO8601 timestamp")
+        conditions.append("p.timestamp >= %s")
+        params.append(since_dt)
 
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
@@ -425,6 +433,27 @@ def _get_fields_for_researchers(researcher_ids: list[int]) -> dict[int, list[dic
     return result
 
 
+# Top-20 economics department keywords for preset filtering
+_TOP20_DEPT_KEYWORDS = [
+    "MIT", "Massachusetts Institute of Technology",
+    "Harvard", "Princeton", "Stanford",
+    "University of Chicago",
+    "UC Berkeley", "University of California, Berkeley",
+    "Columbia", "Yale", "Northwestern",
+    "University of Pennsylvania",
+    "New York University", "NYU",
+    "Duke",
+    "University of Michigan",
+    "University of Minnesota",
+    "Cornell",
+    "UCLA", "University of California, Los Angeles",
+    "UC San Diego", "University of California, San Diego",
+    "University of Wisconsin",
+    "Boston University",
+    "Carnegie Mellon",
+]
+
+
 # ---------------------------------------------------------------------------
 # Researcher endpoints
 # ---------------------------------------------------------------------------
@@ -438,10 +467,52 @@ async def list_fields(request: Request):
 
 @app.get("/api/researchers")
 @limiter.limit("60/minute")
-async def list_researchers(request: Request, response: Response):
-    rows = Database.fetch_all(
-        "SELECT id, first_name, last_name, position, affiliation FROM researchers"
+async def list_researchers(
+    request: Request,
+    response: Response,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+    institution: str | None = Query(None),
+    field: str | None = Query(None),
+    position: str | None = Query(None),
+    preset: str | None = Query(None),
+):
+    conditions = []
+    params: list = []
+
+    if institution:
+        conditions.append("r.affiliation LIKE %s")
+        params.append(f"%{institution}%")
+    if position:
+        conditions.append("r.position LIKE %s")
+        params.append(f"%{position}%")
+    if preset == "top20":
+        dept_conditions = " OR ".join(["r.affiliation LIKE %s"] * len(_TOP20_DEPT_KEYWORDS))
+        conditions.append(f"({dept_conditions})")
+        params.extend(f"%{kw}%" for kw in _TOP20_DEPT_KEYWORDS)
+    # ?field= filtering depends on the field taxonomy table (Issue #11); stubbed until that schema lands
+
+    where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+    # Total count
+    count_row = Database.fetch_one(
+        f"SELECT COUNT(*) FROM researchers r {where}", params or None
     )
+    total = count_row[0] if count_row else 0
+    pages = math.ceil(total / per_page) if total else 0
+
+    offset = (page - 1) * per_page
+    rows = Database.fetch_all(
+        f"""
+        SELECT r.id, r.first_name, r.last_name, r.position, r.affiliation, r.bio
+        FROM researchers r
+        {where}
+        ORDER BY r.last_name, r.first_name
+        LIMIT %s OFFSET %s
+        """,
+        (*params, per_page, offset),
+    )
+
     researcher_ids = [r[0] for r in rows]
     urls_by_researcher = _get_urls_for_researchers(researcher_ids)
     pub_counts = _get_pub_counts_for_researchers(researcher_ids)
@@ -453,6 +524,7 @@ async def list_researchers(request: Request, response: Response):
             "last_name": r[2],
             "position": r[3],
             "affiliation": r[4],
+            "bio": r[5],
             "urls": urls_by_researcher.get(r[0], []),
             "website_url": _get_website_url(urls_by_researcher.get(r[0], [])),
             "publication_count": pub_counts.get(r[0], 0),
@@ -461,14 +533,20 @@ async def list_researchers(request: Request, response: Response):
         for r in rows
     ]
     response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=600"
-    return {"items": items}
+    return {
+        "items": items,
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+        "pages": pages,
+    }
 
 
 @app.get("/api/researchers/{researcher_id}")
 @limiter.limit("60/minute")
 async def get_researcher(request: Request, researcher_id: int):
     row = Database.fetch_one(
-        "SELECT id, first_name, last_name, position, affiliation FROM researchers WHERE id = %s",
+        "SELECT id, first_name, last_name, position, affiliation, bio FROM researchers WHERE id = %s",
         (researcher_id,),
     )
     if not row:
@@ -499,6 +577,7 @@ async def get_researcher(request: Request, researcher_id: int):
         "last_name": row[2],
         "position": row[3],
         "affiliation": row[4],
+        "bio": row[5],
         "urls": urls,
         "website_url": _get_website_url(urls),
         "publication_count": pub_count,

--- a/database.py
+++ b/database.py
@@ -109,6 +109,7 @@ class Database:
                     first_name VARCHAR(255) NOT NULL,
                     position VARCHAR(255),
                     affiliation VARCHAR(255),
+                    bio TEXT,
                     INDEX idx_name (last_name, first_name)
                 )
             """,
@@ -201,6 +202,11 @@ class Database:
             with conn.cursor() as cursor:
                 for table_query in table_definitions.values():
                     cursor.execute(table_query)
+
+        # Migration: add bio column to existing researchers tables
+        Database.execute_query(
+            "ALTER TABLE researchers ADD COLUMN IF NOT EXISTS bio TEXT"
+        )
         logging.info("All tables created successfully")
         Database.seed_research_fields()
 
@@ -365,6 +371,14 @@ class Database:
         """
         new_id = Database.execute_query(insert_query, (first_name, last_name, position, affiliation))
         return new_id
+
+    @staticmethod
+    def update_researcher_bio(researcher_id, bio):
+        """Update researcher bio only if the current bio is NULL."""
+        Database.execute_query(
+            "UPDATE researchers SET bio = %s WHERE id = %s AND bio IS NULL",
+            (bio, researcher_id),
+        )
 
     @staticmethod
     def add_researcher_url(researcher_id, page_type, url):

--- a/html_fetcher.py
+++ b/html_fetcher.py
@@ -312,6 +312,39 @@ class HTMLFetcher:
         return False
 
     @staticmethod
+    def extract_bio(text_content: str, url: str) -> str | None:
+        """Extract a ≤2-sentence bio from text content using the LLM.
+
+        Returns the bio string, or None if no bio could be extracted.
+        Import is deferred to avoid circular dependency with publication.py.
+        """
+        try:
+            from publication import _openai_client, OPENAI_MODEL
+        except ImportError:
+            logging.error("Could not import OpenAI client for bio extraction")
+            return None
+
+        prompt = (
+            f"From the following text from a researcher's homepage at {url}, "
+            "extract a brief professional bio (at most 2 sentences) describing who this person is, "
+            "their research interests, and their current position/affiliation. "
+            "If no clear bio can be extracted, reply with exactly: null\n\n"
+            f"Content:\n{text_content[:3000]}"
+        )
+        try:
+            response = _openai_client.chat.completions.create(
+                messages=[{"role": "user", "content": prompt}],
+                model=OPENAI_MODEL,
+            )
+            bio = response.choices[0].message.content.strip()
+            if bio.lower() in ("null", "none", ""):
+                return None
+            return bio[:500]
+        except Exception as e:
+            logging.error(f"Error extracting bio from {url}: {e}")
+            return None
+
+    @staticmethod
     def get_latest_text(url_id):
         """Retrieve the latest text content for a given URL ID."""
         query = """

--- a/scheduler.py
+++ b/scheduler.py
@@ -127,6 +127,18 @@ def run_scrape_job():
                         Publication.save_publications(url, pubs)
                         pubs_extracted += len(pubs)
 
+            # Extract bio from HOME pages only when bio is not yet set
+            if page_type == "HOME":
+                bio_row = Database.fetch_one(
+                    "SELECT bio FROM researchers WHERE id = %s", (researcher_id,)
+                )
+                if bio_row and bio_row[0] is None:
+                    page_text = HTMLFetcher.get_latest_text(url_id)
+                    if page_text:
+                        bio = HTMLFetcher.extract_bio(page_text, url)
+                        if bio:
+                            Database.update_researcher_bio(researcher_id, bio)
+
         update_scrape_log(log_id, "completed", urls_checked, urls_changed, pubs_extracted)
         logger.info(f"Scrape completed: {urls_checked} checked, {urls_changed} changed, {pubs_extracted} extracted")
 

--- a/tests/test_api_publications.py
+++ b/tests/test_api_publications.py
@@ -140,6 +140,27 @@ class TestListPublications:
         response = client.get("/api/publications?page=-1")
         assert response.status_code == 400
 
+    def test_since_filter(self, client):
+        """?since= filters publications discovered after the given timestamp."""
+        with (
+            patch("api.Database.fetch_one", return_value=(1,)),
+            patch("api.Database.fetch_all") as mock_fetch,
+        ):
+            mock_fetch.side_effect = [
+                [SAMPLE_PUBLICATIONS[0]],
+                SAMPLE_AUTHORS_PUB1,
+            ]
+            response = client.get("/api/publications?since=2026-03-15T00:00:00Z")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["items"]) == 1
+
+    def test_since_invalid_format_returns_400(self, client):
+        """Invalid ?since= value returns 400."""
+        response = client.get("/api/publications?since=not-a-date")
+        assert response.status_code == 400
+
     def test_publication_item_shape(self, client):
         """Each item must have id, title, authors, year, venue, source_url, discovered_at."""
         with (

--- a/tests/test_api_researchers.py
+++ b/tests/test_api_researchers.py
@@ -22,9 +22,9 @@ def client():
 
 # Sample DB return shapes
 SAMPLE_RESEARCHERS = [
-    # (id, first_name, last_name, position, affiliation)
-    (1, "Max Friedrich", "Steinhardt", "Professor", "Freie Universität Berlin"),
-    (2, "Jane", "Doe", "Assistant Professor", "MIT"),
+    # (id, first_name, last_name, position, affiliation, bio)
+    (1, "Max Friedrich", "Steinhardt", "Professor", "Freie Universität Berlin", "A leading researcher in trade economics."),
+    (2, "Jane", "Doe", "Assistant Professor", "MIT", None),
 ]
 
 SAMPLE_URLS_R1 = [
@@ -46,20 +46,27 @@ SAMPLE_PUB_COUNT_R2 = (5,)
 BATCH_URLS_ALL = [
     (1, 10, "PUB", "https://example.com/steinhardt/pubs"),
     (1, 11, "WP", "https://example.com/steinhardt/wp"),
+    (1, 12, "homepage", "https://steinhardt.example.com"),
     (2, 20, "PUB", "https://example.com/doe/pubs"),
 ]
 BATCH_URLS_R1 = [
     (1, 10, "PUB", "https://example.com/steinhardt/pubs"),
     (1, 11, "WP", "https://example.com/steinhardt/wp"),
+    (1, 12, "homepage", "https://steinhardt.example.com"),
+]
+BATCH_URLS_R2 = [
+    (2, 20, "PUB", "https://example.com/doe/pubs"),
 ]
 # (researcher_id, count)
 BATCH_PUB_COUNTS_ALL = [(1, 23), (2, 5)]
 BATCH_PUB_COUNTS_R1 = [(1, 23)]
+BATCH_PUB_COUNTS_R2 = [(2, 5)]
 # (researcher_id, field.id, field.name, field.slug)
 BATCH_FIELDS_ALL = [(1, 1, "Labour Economics", "labour-economics")]
 BATCH_FIELDS_R1 = [(1, 1, "Labour Economics", "labour-economics")]
+BATCH_FIELDS_R2 = []
 
-SAMPLE_RESEARCHER_DETAIL = (1, "Max Friedrich", "Steinhardt", "Professor", "Freie Universität Berlin")
+SAMPLE_RESEARCHER_DETAIL = (1, "Max Friedrich", "Steinhardt", "Professor", "Freie Universität Berlin", "A leading researcher in trade economics.")
 
 SAMPLE_PUBLICATIONS_R1 = [
     # (pub.id, pub.title, pub.year, pub.venue, pub.url, pub.timestamp, pub.status, pub.draft_url)
@@ -80,9 +87,15 @@ class TestListResearchers:
     """Tests for GET /api/researchers."""
 
     def test_returns_all_researchers(self, client):
-        with patch("api.Database.fetch_all") as mock_fetch:
+        with (
+            patch("api.Database.fetch_one") as mock_one,
+            patch("api.Database.fetch_all") as mock_fetch,
+        ):
+            mock_one.side_effect = [
+                (2,),                    # total count
+            ]
             mock_fetch.side_effect = [
-                SAMPLE_RESEARCHERS,      # researchers query
+                SAMPLE_RESEARCHERS,      # paginated researchers
                 BATCH_URLS_ALL,          # batch URLs for all researchers
                 BATCH_PUB_COUNTS_ALL,    # batch pub counts for all researchers
                 BATCH_FIELDS_ALL,        # batch fields for all researchers
@@ -92,10 +105,20 @@ class TestListResearchers:
         assert response.status_code == 200
         body = response.json()
         assert len(body["items"]) == 2
+        assert "total" in body
+        assert "page" in body
+        assert "per_page" in body
+        assert "pages" in body
 
     def test_researcher_item_shape(self, client):
-        """Each researcher must have id, first_name, last_name, position, affiliation, urls, website_url, publication_count, fields."""
-        with patch("api.Database.fetch_all") as mock_fetch:
+        """Each researcher must have id, first_name, last_name, position, affiliation, bio, urls, website_url, publication_count, fields."""
+        with (
+            patch("api.Database.fetch_one") as mock_one,
+            patch("api.Database.fetch_all") as mock_fetch,
+        ):
+            mock_one.side_effect = [
+                (1,),                # total count
+            ]
             mock_fetch.side_effect = [
                 [SAMPLE_RESEARCHERS[0]],
                 BATCH_URLS_R1,
@@ -111,6 +134,7 @@ class TestListResearchers:
         assert item["position"] == "Professor"
         assert item["affiliation"] == "Freie Universität Berlin"
         assert item["publication_count"] == 23
+        assert "bio" in item
         assert len(item["urls"]) == 3
         assert item["urls"][0]["id"] == 10
         assert item["urls"][0]["page_type"] == "PUB"
@@ -118,6 +142,140 @@ class TestListResearchers:
         assert item["website_url"] == "https://steinhardt.example.com"
         assert len(item["fields"]) == 1
         assert item["fields"][0]["name"] == "Labour Economics"
+
+    def test_default_pagination(self, client):
+        """Default page=1, per_page=20; response includes pagination metadata."""
+        with (
+            patch("api.Database.fetch_one") as mock_one,
+            patch("api.Database.fetch_all") as mock_fetch,
+        ):
+            mock_one.side_effect = [
+                (2,),                    # total count
+            ]
+            mock_fetch.side_effect = [
+                SAMPLE_RESEARCHERS,      # paginated researchers
+                BATCH_URLS_ALL,          # batch URLs
+                BATCH_PUB_COUNTS_ALL,    # batch pub counts
+                BATCH_FIELDS_ALL,        # batch fields
+            ]
+            response = client.get("/api/researchers")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["page"] == 1
+        assert body["per_page"] == 20
+        assert body["total"] == 2
+        assert body["pages"] == 1
+
+    def test_custom_pagination(self, client):
+        """Custom page and per_page values."""
+        with (
+            patch("api.Database.fetch_one") as mock_one,
+            patch("api.Database.fetch_all") as mock_fetch,
+        ):
+            mock_one.side_effect = [
+                (2,),                    # total count
+            ]
+            mock_fetch.side_effect = [
+                [SAMPLE_RESEARCHERS[1]], # paginated researchers (page 2)
+                BATCH_URLS_R2,           # batch URLs
+                BATCH_PUB_COUNTS_R2,     # batch pub counts
+                BATCH_FIELDS_R2,         # batch fields
+            ]
+            response = client.get("/api/researchers?page=2&per_page=1")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["page"] == 2
+        assert body["per_page"] == 1
+        assert body["pages"] == 2
+
+    def test_per_page_capped_at_100(self, client):
+        """per_page > 100 should be rejected as 400."""
+        response = client.get("/api/researchers?per_page=200")
+        assert response.status_code == 400
+
+    def test_invalid_page_returns_400(self, client):
+        response = client.get("/api/researchers?page=-1")
+        assert response.status_code == 400
+
+    def test_institution_filter(self, client):
+        """?institution= performs partial match on affiliation."""
+        with (
+            patch("api.Database.fetch_one") as mock_one,
+            patch("api.Database.fetch_all") as mock_fetch,
+        ):
+            mock_one.side_effect = [
+                (1,),                    # total count
+            ]
+            mock_fetch.side_effect = [
+                [SAMPLE_RESEARCHERS[1]], # paginated researchers
+                BATCH_URLS_R2,           # batch URLs
+                BATCH_PUB_COUNTS_R2,     # batch pub counts
+                BATCH_FIELDS_R2,         # batch fields
+            ]
+            response = client.get("/api/researchers?institution=MIT")
+
+        assert response.status_code == 200
+        assert len(response.json()["items"]) == 1
+
+    def test_position_filter(self, client):
+        """?position= performs partial match on position."""
+        with (
+            patch("api.Database.fetch_one") as mock_one,
+            patch("api.Database.fetch_all") as mock_fetch,
+        ):
+            mock_one.side_effect = [
+                (1,),                        # total count
+            ]
+            mock_fetch.side_effect = [
+                [SAMPLE_RESEARCHERS[0]],     # paginated researchers
+                BATCH_URLS_R1,               # batch URLs
+                BATCH_PUB_COUNTS_R1,         # batch pub counts
+                BATCH_FIELDS_R1,             # batch fields
+            ]
+            response = client.get("/api/researchers?position=Professor")
+
+        assert response.status_code == 200
+        assert len(response.json()["items"]) == 1
+
+    def test_preset_top20_accepted(self, client):
+        """?preset=top20 is accepted and returns 200."""
+        with (
+            patch("api.Database.fetch_one") as mock_one,
+            patch("api.Database.fetch_all") as mock_fetch,
+        ):
+            mock_one.side_effect = [
+                (1,),                        # total count
+            ]
+            mock_fetch.side_effect = [
+                [SAMPLE_RESEARCHERS[1]],     # paginated researchers
+                BATCH_URLS_R2,               # batch URLs
+                BATCH_PUB_COUNTS_R2,         # batch pub counts
+                BATCH_FIELDS_R2,             # batch fields
+            ]
+            response = client.get("/api/researchers?preset=top20")
+
+        assert response.status_code == 200
+
+    def test_field_filter_stubbed(self, client):
+        """?field= is accepted without error (stubbed until taxonomy table lands)."""
+        with (
+            patch("api.Database.fetch_one") as mock_one,
+            patch("api.Database.fetch_all") as mock_fetch,
+        ):
+            mock_one.side_effect = [
+                (2,),                    # total count
+            ]
+            mock_fetch.side_effect = [
+                SAMPLE_RESEARCHERS,      # paginated researchers
+                BATCH_URLS_ALL,          # batch URLs
+                BATCH_PUB_COUNTS_ALL,    # batch pub counts
+                BATCH_FIELDS_ALL,        # batch fields
+            ]
+            response = client.get("/api/researchers?field=labor")
+
+        assert response.status_code == 200
 
 
 # ---------------------------------------------------------------------------
@@ -148,6 +306,7 @@ class TestGetResearcher:
         body = response.json()
         assert body["id"] == 1
         assert body["first_name"] == "Max Friedrich"
+        assert "bio" in body
         assert "publications" in body
         assert len(body["publications"]) == 1
         assert body["website_url"] == "https://steinhardt.example.com"


### PR DESCRIPTION
Implements issue #9:

- #19: Add page/per_page query params to GET /api/researchers
- #12a: Add ?since=<ISO8601> filter to GET /api/publications
- #12b: Add bio TEXT column, LLM bio extraction, expose in API
- #13: Add ?institution=, ?position=, ?preset=top20, ?field= (stub) filters

Closes #9

Generated with [Claude Code](https://claude.ai/code)