### PR TITLE
feat: decouple HTML fetch from LLM extraction in scheduler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,12 +53,15 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build  #
 
 ### Pipeline Details
 
-**`make scrape`** runs the full scheduler job (`scheduler.run_scrape_job()`):
-1. **Fetch phase**: Download HTML for all researcher URLs, skip unchanged (content hash)
-2. **Extract phase**: LLM extracts publications from changed pages, saves to `papers`
-3. **Link matching**: Extract trusted-domain links from HTML, match to papers via DOI resolution (regex/Crossref) or anchor text, save to `paper_links`
-4. **Draft URL validation**: HEAD-request validation of `draft_url` fields
-5. **Enrichment phase** (after releasing scrape lock): Enrich unenriched papers via OpenAlex — DOI lookup first (from `paper_links`), title search fallback (published papers only)
+**`make scrape`** runs the full scheduler job (`scheduler.run_scrape_job()`). Fetch and extract run as **separate phases** — fetch always completes even if the LLM provider is down:
+1. **Fetch phase** (all URLs): Download HTML for all researcher URLs, skip unchanged (content hash). Collects list of changed URLs.
+2. **Extract phase** (changed URLs only): LLM extracts publications from changed pages, saves to `papers`. Includes link matching, title reconciliation, and paper snapshots.
+3. **Draft URL validation**: HEAD-request validation of `draft_url` fields
+4. **Enrichment phase** (after releasing scrape lock): Enrich unenriched papers via OpenAlex — DOI lookup first (from `paper_links`), title search fallback (published papers only)
+
+**Extraction circuit breaker:** If 10 consecutive URLs return empty extraction results (e.g. LLM quota exhausted), the extraction phase stops early. Fetched HTML is preserved — extraction will resume on the next run for URLs where `content_hash ≠ extracted_hash`. The `scrape_log.extraction_errors` column tracks how many URLs failed extraction per run.
+
+**Stale scrape_log cleanup:** On scheduler start, any `scrape_log` entries stuck in `'running'` for >24 hours are automatically marked as `'failed'`.
 
 **`make fetch`** runs stage 1 only (download HTML). Extraction is handled exclusively by `make scrape` (scheduler), which uses diff-based extraction — the only path that correctly creates feed events.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ make reset-db             # Drop and recreate database from scratch
 # Scraping pipeline
 make scrape               # Full pipeline: fetch HTML → LLM extract → save → link match → enrich
 make fetch                # Stage 1: Download HTML from researcher URLs (hash-based change detection)
+make batch-submit         # Stage 2: Submit changed URLs to OpenAI Batch API for extraction
+make batch-check          # Stage 3: Process completed batch results → save papers, snapshots, links
 
 # Enrichment & classification
 make enrich               # Enrich papers via OpenAlex (DOI lookup first, title search fallback)
@@ -59,6 +61,13 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build  #
 5. **Enrichment phase** (after releasing scrape lock): Enrich unenriched papers via OpenAlex — DOI lookup first (from `paper_links`), title search fallback (published papers only)
 
 **`make fetch`** runs stage 1 only (download HTML). Extraction is handled exclusively by `make scrape` (scheduler), which uses diff-based extraction — the only path that correctly creates feed events.
+
+**Granular batch pipeline** (run stages independently):
+1. `make fetch` — Download HTML, detect changes via content hash. Safe to run anytime.
+2. `make batch-submit` — Submit URLs where `content_hash ≠ extracted_hash` to OpenAI Batch API. Requires fetch first.
+3. `make batch-check` — Poll pending batches, process results (save papers, snapshots, links, feed events). Idempotent for completed batches.
+
+Each stage is independently safe. Feed event integrity is protected by `_title_in_previous_snapshot()` and the `_url_has_baseline()` check regardless of which pipeline path is used.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev kill seed reset-db scrape fetch classify-jel enrich enrich-jel discover-domains backfill-normalize populate-fields backfill-affiliations audit-zero-pubs check
+.PHONY: setup dev kill seed reset-db scrape fetch batch-submit batch-check classify-jel enrich enrich-jel discover-domains backfill-normalize populate-fields backfill-affiliations audit-zero-pubs check
 
 setup:
 	poetry install
@@ -33,6 +33,12 @@ scrape:
 
 fetch:
 	poetry run python -c "from main import download_htmls; download_htmls()"
+
+batch-submit:
+	poetry run python main.py batch-submit
+
+batch-check:
+	poetry run python main.py batch-check
 
 classify-jel:
 	poetry run python -c "from main import classify_jel; classify_jel()"

--- a/database/schema.py
+++ b/database/schema.py
@@ -621,6 +621,18 @@ def create_tables() -> None:
                     except Exception as e:
                         if "Duplicate column name" not in str(e):
                             logging.warning("Migration: feed_events title columns: %s", e)
+
+                    # Add extraction_errors column to scrape_log
+                    try:
+                        cursor.execute("""
+                            ALTER TABLE scrape_log
+                            ADD COLUMN extraction_errors INT DEFAULT 0 AFTER pubs_extracted
+                        """)
+                        conn.commit()
+                        logging.info("Migration: added extraction_errors to scrape_log")
+                    except Exception as e:
+                        if "Duplicate column name" not in str(e):
+                            logging.warning("Migration: scrape_log.extraction_errors: %s", e)
                 finally:
                     cursor.execute("SELECT RELEASE_LOCK('econ_migrations')")
                     cursor.fetchone()

--- a/main.py
+++ b/main.py
@@ -355,6 +355,8 @@ def main() -> None:
     subparsers.add_parser('enrich', help='Enrich publications with OpenAlex metadata')
     subparsers.add_parser('enrich-jel', help='Enrich researcher JEL codes from paper topics via OpenAlex')
     subparsers.add_parser('discover-domains', help='Scan stored HTML for untrusted domains with paper-title links')
+    subparsers.add_parser('batch-submit', help='Submit batch LLM extraction for URLs with new content')
+    subparsers.add_parser('batch-check', help='Check pending batches and process completed results')
 
     args = parser.parse_args()
 
@@ -374,6 +376,10 @@ def main() -> None:
         enrich_jel_from_papers()
     elif args.command == 'discover-domains':
         discover_domains()
+    elif args.command == 'batch-submit':
+        batch_submit()
+    elif args.command == 'batch-check':
+        batch_check()
 
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -253,6 +253,25 @@ def batch_check() -> None:
                     Publication.save_publications(url, validated, is_seed=is_seed)
                     reconcile_title_renames(url, validated)
                     match_and_save_paper_links(url_id, validated)
+
+                    # Append paper snapshots (mirrors scheduler.py:218-236)
+                    for pub in validated:
+                        title_hash = Database.compute_title_hash(pub['title'])
+                        paper_row = Database.fetch_one(
+                            "SELECT id FROM papers WHERE title_hash = %s", (title_hash,)
+                        )
+                        if paper_row:
+                            Database.append_paper_snapshot(
+                                paper_id=paper_row['id'],
+                                status=pub.get('status'),
+                                venue=pub.get('venue'),
+                                abstract=pub.get('abstract'),
+                                draft_url=pub.get('draft_url'),
+                                year=pub.get('year'),
+                                source_url=url,
+                                title=pub.get('title'),
+                            )
+
                     saved_pubs += len(validated)
                 HTMLFetcher.mark_extracted(url_id)
                 processed_urls += 1

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import os
 
 from database import Database
 from researcher import Researcher
-from publication import Publication, reconcile_title_renames, validate_publication
+from publication import Publication, reconcile_title_renames, validate_publication, append_snapshots_for_pubs
 from html_fetcher import HTMLFetcher
 from link_extractor import match_and_save_paper_links
 
@@ -254,23 +254,7 @@ def batch_check() -> None:
                     reconcile_title_renames(url, validated)
                     match_and_save_paper_links(url_id, validated)
 
-                    # Append paper snapshots (mirrors scheduler.py:218-236)
-                    for pub in validated:
-                        title_hash = Database.compute_title_hash(pub['title'])
-                        paper_row = Database.fetch_one(
-                            "SELECT id FROM papers WHERE title_hash = %s", (title_hash,)
-                        )
-                        if paper_row:
-                            Database.append_paper_snapshot(
-                                paper_id=paper_row['id'],
-                                status=pub.get('status'),
-                                venue=pub.get('venue'),
-                                abstract=pub.get('abstract'),
-                                draft_url=pub.get('draft_url'),
-                                year=pub.get('year'),
-                                source_url=url,
-                                title=pub.get('title'),
-                            )
+                    append_snapshots_for_pubs(validated, url)
 
                     saved_pubs += len(validated)
                 HTMLFetcher.mark_extracted(url_id)

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import os
 
 from database import Database
 from researcher import Researcher
-from publication import Publication, reconcile_title_renames
+from publication import Publication, reconcile_title_renames, validate_publication
 from html_fetcher import HTMLFetcher
 from link_extractor import match_and_save_paper_links
 
@@ -240,7 +240,11 @@ def batch_check() -> None:
                         continue
                     try:
                         pub = PublicationExtraction(**item)
-                        validated.append(pub.model_dump())
+                        d = pub.model_dump()
+                        if validate_publication(d):
+                            validated.append(d)
+                        else:
+                            logging.info("Batch validation dropped: %s", d.get("title", "<no title>"))
                     except (ValidationError, TypeError) as e:
                         logging.warning(f"Rejected malformed batch publication: {e}")
 

--- a/publication.py
+++ b/publication.py
@@ -566,6 +566,39 @@ def _title_similarity(title_a: str | None, title_b: str | None) -> float:
     return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
 
 
+def append_snapshots_for_pubs(pubs: list[dict], source_url: str) -> None:
+    """Append paper snapshots for a batch of extracted publications.
+
+    Resolves title_hash → paper_id in a single query, then appends
+    a snapshot for each matched paper.
+    """
+    hash_to_pub = {}
+    for pub in pubs:
+        title = pub.get('title')
+        if title:
+            hash_to_pub[Database.compute_title_hash(title)] = pub
+    if not hash_to_pub:
+        return
+
+    placeholders = ",".join(["%s"] * len(hash_to_pub))
+    rows = Database.fetch_all(
+        f"SELECT id, title_hash FROM papers WHERE title_hash IN ({placeholders})",
+        list(hash_to_pub.keys()),
+    )
+    for row in rows:
+        pub = hash_to_pub[row['title_hash']]
+        Database.append_paper_snapshot(
+            paper_id=row['id'],
+            status=pub.get('status'),
+            venue=pub.get('venue'),
+            abstract=pub.get('abstract'),
+            draft_url=pub.get('draft_url'),
+            year=pub.get('year'),
+            source_url=source_url,
+            title=pub.get('title'),
+        )
+
+
 _SIMILARITY_THRESHOLD = 0.5
 
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -12,7 +12,7 @@ from database import Database
 from db_config import db_config
 from researcher import Researcher
 from html_fetcher import HTMLFetcher
-from publication import Publication, reconcile_title_renames
+from publication import Publication, reconcile_title_renames, append_snapshots_for_pubs
 from link_extractor import match_and_save_paper_links
 
 logger = logging.getLogger(__name__)
@@ -216,22 +216,7 @@ def run_scrape_job() -> None:
 
                             # Append paper snapshots for versioning
                             t0 = time.time()
-                            for pub in pubs:
-                                title_hash = Database.compute_title_hash(pub['title'])
-                                paper_row = Database.fetch_one(
-                                    "SELECT id FROM papers WHERE title_hash = %s", (title_hash,)
-                                )
-                                if paper_row:
-                                    Database.append_paper_snapshot(
-                                        paper_id=paper_row['id'],
-                                        status=pub.get('status'),
-                                        venue=pub.get('venue'),
-                                        abstract=pub.get('abstract'),
-                                        draft_url=pub.get('draft_url'),
-                                        year=pub.get('year'),
-                                        source_url=url,
-                                        title=pub.get('title'),
-                                    )
+                            append_snapshots_for_pubs(pubs, url)
                             snapshot_ms = (time.time() - t0) * 1000
                             logger.info(f"  paper snapshots — {snapshot_ms:.0f}ms")
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -80,7 +80,7 @@ def create_scrape_log() -> int:
     return Database.execute_query(query, (datetime.now(timezone.utc),))
 
 
-def update_scrape_log(log_id: int, status: str, urls_checked: int = 0, urls_changed: int = 0, pubs_extracted: int = 0, error_message: str | None = None) -> None:
+def update_scrape_log(log_id: int, status: str, urls_checked: int = 0, urls_changed: int = 0, pubs_extracted: int = 0, extraction_errors: int = 0, error_message: str | None = None) -> None:
     """Update an existing scrape_log entry with results."""
     # Aggregate token totals from llm_usage for this scrape run
     token_row = Database.fetch_one(
@@ -95,13 +95,14 @@ def update_scrape_log(log_id: int, status: str, urls_checked: int = 0, urls_chan
     query = """
         UPDATE scrape_log
         SET finished_at = %s, status = %s, urls_checked = %s,
-            urls_changed = %s, pubs_extracted = %s, error_message = %s,
+            urls_changed = %s, pubs_extracted = %s, extraction_errors = %s,
+            error_message = %s,
             prompt_tokens_total = %s, completion_tokens_total = %s
         WHERE id = %s
     """
     Database.execute_query(query, (
         datetime.now(timezone.utc), status, urls_checked,
-        urls_changed, pubs_extracted, error_message,
+        urls_changed, pubs_extracted, extraction_errors, error_message,
         prompt_tokens_total, completion_tokens_total, log_id
     ))
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -112,23 +112,16 @@ _STALE_SCRAPE_HOURS = 24
 
 def _cleanup_stale_scrape_logs() -> None:
     """Mark scrape_log entries stuck in 'running' for >24h as 'failed'."""
-    stale = Database.fetch_all(
-        """SELECT id, started_at FROM scrape_log
+    affected = Database.execute_query(
+        """UPDATE scrape_log
+           SET finished_at = NOW(), status = 'failed',
+               error_message = 'Stale running entry — cleaned up on scheduler start'
            WHERE status = 'running'
              AND started_at < DATE_SUB(NOW(), INTERVAL %s HOUR)""",
         (_STALE_SCRAPE_HOURS,),
     )
-    if not stale:
-        return
-    logger.info("Cleaning up %d stale scrape_log entries", len(stale))
-    for row in stale:
-        Database.execute_query(
-            """UPDATE scrape_log
-               SET finished_at = NOW(), status = %s, error_message = %s
-               WHERE id = %s""",
-            ("failed", "Stale running entry — cleaned up on scheduler start", row['id']),
-        )
-        logger.info("Marked scrape_log id=%d (started %s) as failed", row['id'], row['started_at'])
+    if affected:
+        logger.info("Cleaned up %d stale scrape_log entries", affected)
 
 
 _DRAFT_VALIDATION_BUDGET_SECONDS = 300  # 5-minute time budget
@@ -216,10 +209,7 @@ def run_scrape_job() -> None:
                 if changed:
                     urls_changed += 1
                     changed_urls.append({
-                        'url_id': url_id,
-                        'researcher_id': researcher_id,
-                        'url': url,
-                        'page_type': page_type,
+                        **url_row,
                         'old_text': old_text,
                         'is_first_scrape': is_first_scrape,
                     })
@@ -237,12 +227,12 @@ def run_scrape_job() -> None:
         circuit_broken = False
 
         for idx, entry in enumerate(changed_urls):
-            url_id = entry['url_id']
+            url_id = entry['id']
             researcher_id = entry['researcher_id']
             url = entry['url']
             page_type = entry['page_type']
-            old_text = entry['old_text']
-            is_first_scrape = entry['is_first_scrape']
+            old_text = entry.pop('old_text')
+            is_first_scrape = entry.pop('is_first_scrape')
 
             if circuit_broken:
                 break
@@ -294,27 +284,34 @@ def run_scrape_job() -> None:
                             )
                             circuit_broken = True
 
-                if page_type == "HOME" and not circuit_broken:
-                    page_text = HTMLFetcher.get_latest_text(url_id)
-                    if page_text:
-                        t0 = time.time()
-                        description = HTMLFetcher.extract_description(page_text, url, scrape_log_id=log_id)
-                        desc_ms = (time.time() - t0) * 1000
-                        logger.info(f"  description extract — {desc_ms:.0f}ms (found={description is not None})")
-                        if description:
-                            r_row = Database.fetch_one(
-                                "SELECT position, affiliation FROM researchers WHERE id = %s",
-                                (researcher_id,),
-                            )
-                            position = r_row['position'] if r_row else None
-                            affiliation = r_row['affiliation'] if r_row else None
-                            Database.append_researcher_snapshot(
-                                researcher_id, position, affiliation, description, source_url=url
-                            )
+                if page_type == "HOME" and not circuit_broken and new_text:
+                    t0 = time.time()
+                    description = HTMLFetcher.extract_description(new_text, url, scrape_log_id=log_id)
+                    desc_ms = (time.time() - t0) * 1000
+                    logger.info(f"  description extract — {desc_ms:.0f}ms (found={description is not None})")
+                    if description:
+                        r_row = Database.fetch_one(
+                            "SELECT position, affiliation FROM researchers WHERE id = %s",
+                            (researcher_id,),
+                        )
+                        position = r_row['position'] if r_row else None
+                        affiliation = r_row['affiliation'] if r_row else None
+                        Database.append_researcher_snapshot(
+                            researcher_id, position, affiliation, description, source_url=url
+                        )
 
             except Exception as e:
                 logger.error("Error extracting URL %s (id=%s): %s", url, url_id, e)
                 extraction_errors += 1
+                consecutive_failures += 1
+                if consecutive_failures >= _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD:
+                    remaining = len(changed_urls) - idx - 1
+                    logger.warning(
+                        "Circuit breaker: %d consecutive extraction failures — "
+                        "stopping extraction. Remaining %d changed URLs will be extracted next run.",
+                        consecutive_failures, remaining,
+                    )
+                    circuit_broken = True
                 continue
 
         extract_phase_s = time.time() - extract_start

--- a/scheduler.py
+++ b/scheduler.py
@@ -142,8 +142,15 @@ def _enrich_with_openalex() -> None:
         logger.error("OpenAlex enrichment failed: %s: %s", type(e).__name__, e)
 
 
+_EXTRACTION_CIRCUIT_BREAKER_THRESHOLD = 10
+
+
 def run_scrape_job() -> None:
-    """Orchestrates a full scraping cycle. Skips if another scrape is running."""
+    """Orchestrates a full scraping cycle: fetch all HTML first, then extract.
+
+    Fetch always completes. Extraction circuit-breaks after
+    _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD consecutive failures (e.g. quota exhausted).
+    """
     global _lock_conn
     lock_conn = _acquire_db_lock()
     if lock_conn is None:
@@ -151,7 +158,6 @@ def run_scrape_job() -> None:
         return
     _lock_conn = lock_conn
 
-    # Clear stale robots.txt cache from previous cycle
     HTMLFetcher._robots_cache.clear()
 
     log_id = None
@@ -161,8 +167,11 @@ def run_scrape_job() -> None:
         urls_checked = 0
         urls_changed = 0
         pubs_extracted = 0
+        extraction_errors = 0
 
+        # ── PHASE 1: Fetch all HTML ──────────────────────────────────
         scrape_start = time.time()
+        changed_urls = []
 
         for url_row in urls:
             url_id = url_row['id']
@@ -170,10 +179,8 @@ def run_scrape_job() -> None:
             url = url_row['url']
             page_type = url_row['page_type']
             urls_checked += 1
-            url_start = time.time()
 
             try:
-                # Get old text before fetch overwrites it (upsert)
                 old_text = HTMLFetcher.get_previous_text(url_id)
                 is_first_scrape = old_text is None
 
@@ -184,46 +191,86 @@ def run_scrape_job() -> None:
 
                 if changed:
                     urls_changed += 1
-                    new_text = HTMLFetcher.get_latest_text(url_id)
+                    changed_urls.append({
+                        'url_id': url_id,
+                        'researcher_id': researcher_id,
+                        'url': url,
+                        'page_type': page_type,
+                        'old_text': old_text,
+                        'is_first_scrape': is_first_scrape,
+                    })
 
-                    # Use diff if old content exists, otherwise full text
-                    extraction_text = HTMLFetcher.compute_diff(old_text, new_text) if old_text else new_text
+            except Exception as e:
+                logger.error("Error fetching URL %s (id=%s): %s", url, url_id, e)
+                continue
 
-                    if extraction_text:
+        fetch_phase_s = time.time() - scrape_start
+        logger.info(f"Fetch phase done: {fetch_phase_s:.1f}s — {urls_checked} checked, {urls_changed} changed")
+
+        # ── PHASE 2: Extract publications from changed URLs ──────────
+        extract_start = time.time()
+        consecutive_failures = 0
+        circuit_broken = False
+
+        for idx, entry in enumerate(changed_urls):
+            url_id = entry['url_id']
+            researcher_id = entry['researcher_id']
+            url = entry['url']
+            page_type = entry['page_type']
+            old_text = entry['old_text']
+            is_first_scrape = entry['is_first_scrape']
+
+            if circuit_broken:
+                break
+
+            try:
+                new_text = HTMLFetcher.get_latest_text(url_id)
+                extraction_text = HTMLFetcher.compute_diff(old_text, new_text) if old_text else new_text
+
+                if extraction_text:
+                    t0 = time.time()
+                    pubs = Publication.extract_publications(extraction_text, url, scrape_log_id=log_id)
+                    extract_ms = (time.time() - t0) * 1000
+                    logger.info(f"  LLM extract {url} — {extract_ms:.0f}ms, {len(pubs)} pubs")
+
+                    if pubs:
+                        consecutive_failures = 0
+
                         t0 = time.time()
-                        pubs = Publication.extract_publications(extraction_text, url, scrape_log_id=log_id)
-                        extract_ms = (time.time() - t0) * 1000
-                        logger.info(f"  LLM extract — {extract_ms:.0f}ms, {len(pubs)} pubs")
+                        Publication.save_publications(url, pubs, is_seed=is_first_scrape)
+                        save_ms = (time.time() - t0) * 1000
+                        logger.info(f"  save_publications — {save_ms:.0f}ms")
 
-                        if pubs:
-                            t0 = time.time()
-                            Publication.save_publications(url, pubs, is_seed=is_first_scrape)
-                            save_ms = (time.time() - t0) * 1000
-                            logger.info(f"  save_publications — {save_ms:.0f}ms")
+                        t0_recon = time.time()
+                        reconcile_title_renames(url, pubs)
+                        recon_ms = (time.time() - t0_recon) * 1000
+                        logger.info(f"  title reconciliation — {recon_ms:.0f}ms")
 
-                            # Reconcile title renames before snapshotting
-                            t0_recon = time.time()
-                            reconcile_title_renames(url, pubs)
-                            recon_ms = (time.time() - t0_recon) * 1000
-                            logger.info(f"  title reconciliation — {recon_ms:.0f}ms")
+                        pubs_extracted += len(pubs)
 
-                            pubs_extracted += len(pubs)
+                        t0 = time.time()
+                        match_and_save_paper_links(url_id, pubs)
+                        links_ms = (time.time() - t0) * 1000
+                        logger.info(f"  paper links — {links_ms:.0f}ms")
 
-                            # Extract and match trusted links
-                            t0 = time.time()
-                            match_and_save_paper_links(url_id, pubs)
-                            links_ms = (time.time() - t0) * 1000
-                            logger.info(f"  paper links — {links_ms:.0f}ms")
+                        t0 = time.time()
+                        append_snapshots_for_pubs(pubs, url)
+                        snapshot_ms = (time.time() - t0) * 1000
+                        logger.info(f"  paper snapshots — {snapshot_ms:.0f}ms")
+                    else:
+                        consecutive_failures += 1
+                        extraction_errors += 1
+                        if consecutive_failures >= _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD:
+                            remaining = len(changed_urls) - idx - 1
+                            logger.warning(
+                                "Circuit breaker: %d consecutive extraction failures — "
+                                "stopping extraction (likely LLM quota exhausted). "
+                                "Remaining %d changed URLs will be extracted next run.",
+                                consecutive_failures, remaining,
+                            )
+                            circuit_broken = True
 
-                            # Append paper snapshots for versioning
-                            t0 = time.time()
-                            append_snapshots_for_pubs(pubs, url)
-                            snapshot_ms = (time.time() - t0) * 1000
-                            logger.info(f"  paper snapshots — {snapshot_ms:.0f}ms")
-
-                # Extract description from HOME pages using append-only versioning
-                # Only re-extract when content actually changed to avoid unnecessary LLM calls
-                if page_type == "HOME" and changed:
+                if page_type == "HOME" and not circuit_broken:
                     page_text = HTMLFetcher.get_latest_text(url_id)
                     if page_text:
                         t0 = time.time()
@@ -241,25 +288,26 @@ def run_scrape_job() -> None:
                                 researcher_id, position, affiliation, description, source_url=url
                             )
 
-                url_ms = (time.time() - url_start) * 1000
-                logger.info(f"  total — {url_ms:.0f}ms")
-
             except Exception as e:
-                logger.error("Error processing URL %s (id=%s): %s", url, url_id, e)
+                logger.error("Error extracting URL %s (id=%s): %s", url, url_id, e)
+                extraction_errors += 1
                 continue
 
-        fetch_phase_s = time.time() - scrape_start
-        logger.info(f"Fetch phase done: {fetch_phase_s:.1f}s for {urls_checked} URLs")
+        extract_phase_s = time.time() - extract_start
+        logger.info(f"Extract phase done: {extract_phase_s:.1f}s — {pubs_extracted} pubs, {extraction_errors} errors")
 
-        # Validate draft URLs after extraction phase
         t0 = time.time()
         _validate_draft_urls()
         validate_s = time.time() - t0
         logger.info(f"Draft URL validation: {validate_s:.1f}s")
 
+        error_msg = None
+        if circuit_broken:
+            error_msg = f"Extraction circuit-breaker tripped after {_EXTRACTION_CIRCUIT_BREAKER_THRESHOLD} consecutive failures"
+
         total_s = time.time() - scrape_start
-        update_scrape_log(log_id, "completed", urls_checked, urls_changed, pubs_extracted)
-        logger.info(f"Scrape completed: {urls_checked} checked, {urls_changed} changed, {pubs_extracted} extracted — {total_s:.1f}s total")
+        update_scrape_log(log_id, "completed", urls_checked, urls_changed, pubs_extracted, extraction_errors, error_msg)
+        logger.info(f"Scrape completed: {urls_checked} checked, {urls_changed} changed, {pubs_extracted} extracted, {extraction_errors} errors — {total_s:.1f}s total")
 
     except Exception as e:
         logger.error("Scrape job failed: %s: %s", type(e).__name__, e)
@@ -269,13 +317,11 @@ def run_scrape_job() -> None:
         _release_db_lock(lock_conn)
         _lock_conn = None
 
-    # Enrich after releasing lock — doesn't need exclusivity and can be slow
     t0 = time.time()
     _enrich_with_openalex()
     enrich_s = time.time() - t0
     logger.info(f"OpenAlex enrichment: {enrich_s:.1f}s")
 
-    # Merge duplicate papers identified by shared DOI/OpenAlex ID
     t0 = time.time()
     try:
         from paper_merge import merge_duplicate_papers

--- a/scheduler.py
+++ b/scheduler.py
@@ -107,6 +107,30 @@ def update_scrape_log(log_id: int, status: str, urls_checked: int = 0, urls_chan
     ))
 
 
+_STALE_SCRAPE_HOURS = 24
+
+
+def _cleanup_stale_scrape_logs() -> None:
+    """Mark scrape_log entries stuck in 'running' for >24h as 'failed'."""
+    stale = Database.fetch_all(
+        """SELECT id, started_at FROM scrape_log
+           WHERE status = 'running'
+             AND started_at < DATE_SUB(NOW(), INTERVAL %s HOUR)""",
+        (_STALE_SCRAPE_HOURS,),
+    )
+    if not stale:
+        return
+    logger.info("Cleaning up %d stale scrape_log entries", len(stale))
+    for row in stale:
+        Database.execute_query(
+            """UPDATE scrape_log
+               SET finished_at = NOW(), status = %s, error_message = %s
+               WHERE id = %s""",
+            ("failed", "Stale running entry — cleaned up on scheduler start", row['id']),
+        )
+        logger.info("Marked scrape_log id=%d (started %s) as failed", row['id'], row['started_at'])
+
+
 _DRAFT_VALIDATION_BUDGET_SECONDS = 300  # 5-minute time budget
 _DRAFT_VALIDATION_DELAY = 0.1  # 100ms between requests
 
@@ -367,6 +391,8 @@ def start_scheduler() -> None:
     except Exception as e:
         logger.warning("Could not acquire scheduler lock: %s — skipping scheduler", e)
         return
+
+    _cleanup_stale_scrape_logs()
 
     # Register signal handlers so cloud container SIGTERM completes the current job
     signal.signal(signal.SIGTERM, _handle_sigterm)

--- a/tests/test_batch_pipeline.py
+++ b/tests/test_batch_pipeline.py
@@ -1,14 +1,4 @@
 """Tests for batch pipeline data integrity — validation and snapshots."""
-import os
-
-# Env vars must be set before any app imports
-os.environ.setdefault("DB_HOST", "localhost")
-os.environ.setdefault("DB_USER", "econ_app")
-os.environ.setdefault("DB_PASSWORD", "secret")
-os.environ.setdefault("DB_NAME", "econ_newsfeed")
-os.environ.setdefault("OPENAI_API_KEY", "test-key")
-os.environ.setdefault("SCRAPE_API_KEY", "test-key")
-
 import unittest
 
 from publication import validate_publication, PublicationExtraction

--- a/tests/test_batch_pipeline.py
+++ b/tests/test_batch_pipeline.py
@@ -1,0 +1,59 @@
+"""Tests for batch pipeline data integrity — validation and snapshots."""
+import os
+
+# Env vars must be set before any app imports
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_USER", "econ_app")
+os.environ.setdefault("DB_PASSWORD", "secret")
+os.environ.setdefault("DB_NAME", "econ_newsfeed")
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("SCRAPE_API_KEY", "test-key")
+
+import unittest
+
+from publication import validate_publication, PublicationExtraction
+
+
+class TestBatchValidationGap(unittest.TestCase):
+    """batch_check must run validate_publication() on each parsed result."""
+
+    def test_garbage_publication_rejected_by_validate(self):
+        """A software-package-like extraction should be rejected by validate_publication."""
+        garbage = {
+            "title": "react-dom",
+            "authors": [["", ""]],
+            "year": None,
+            "venue": None,
+            "status": None,
+            "draft_url": None,
+            "abstract": None,
+        }
+        self.assertFalse(validate_publication(garbage))
+
+    def test_valid_publication_accepted_by_validate(self):
+        """A real economics paper should pass validate_publication."""
+        valid = {
+            "title": "Monetary Policy Shocks and Exchange Rate Dynamics",
+            "authors": [["John", "Smith"], ["Jane", "Doe"]],
+            "year": "2024",
+            "venue": "American Economic Review",
+            "status": "published",
+            "draft_url": None,
+            "abstract": "We study the effect of monetary policy on exchange rates.",
+        }
+        self.assertTrue(validate_publication(valid))
+
+    def test_pydantic_valid_but_content_invalid(self):
+        """Pydantic accepts structurally valid garbage — validate_publication must catch it."""
+        item = {
+            "title": "x",
+            "authors": [["A", "B"]],
+        }
+        pub = PublicationExtraction(**item)
+        dumped = pub.model_dump()
+        self.assertIsNotNone(dumped)
+        self.assertFalse(validate_publication(dumped))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch, call
 import pytest
 
 import scheduler
-from scheduler import run_scrape_job, create_scrape_log, update_scrape_log
+from scheduler import run_scrape_job, create_scrape_log, update_scrape_log, _cleanup_stale_scrape_logs
 
 
 # ---------------------------------------------------------------------------
@@ -691,3 +691,37 @@ class TestExtractionCircuitBreaker:
         finally:
             for p in patches.values():
                 p.stop()
+
+
+# ---------------------------------------------------------------------------
+# 9. Stale scrape_log cleanup
+# ---------------------------------------------------------------------------
+
+class TestStaleLogCleanup:
+    """Verify stale running scrape_log entries get cleaned up."""
+
+    @patch("scheduler.Database.fetch_all")
+    @patch("scheduler.Database.execute_query")
+    def test_marks_old_running_entries_as_failed(self, mock_exec, mock_fetch_all):
+        mock_fetch_all.return_value = [
+            {"id": 6, "started_at": "2026-03-19 22:26:31"},
+            {"id": 9, "started_at": "2026-03-23 15:13:20"},
+        ]
+
+        _cleanup_stale_scrape_logs()
+
+        assert mock_exec.call_count == 2
+        for c in mock_exec.call_args_list:
+            query = c[0][0]
+            params = c[0][1]
+            assert "UPDATE scrape_log" in query
+            assert "failed" in params
+
+    @patch("scheduler.Database.fetch_all")
+    @patch("scheduler.Database.execute_query")
+    def test_skips_when_none_stale(self, mock_exec, mock_fetch_all):
+        mock_fetch_all.return_value = []
+
+        _cleanup_stale_scrape_logs()
+
+        mock_exec.assert_not_called()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -67,7 +67,7 @@ class TestRunScrapeJobHappyPath:
 
             mocks["acquire"].assert_called_once()
             mocks["create_log"].assert_called_once()
-            mocks["update_log"].assert_called_once_with(42, "completed", 0, 0, 0)
+            mocks["update_log"].assert_called_once_with(42, "completed", 0, 0, 0, 0, None)
             mocks["validate"].assert_called_once()
             mocks["release"].assert_called_once()
         finally:
@@ -103,7 +103,7 @@ class TestRunScrapeJobHappyPath:
                 url_row["url"], pubs, is_seed=True,
             )
             mocks["paper_snap"].assert_called_once_with(pubs, url_row["url"])
-            mocks["update_log"].assert_called_once_with(42, "completed", 1, 1, 1)
+            mocks["update_log"].assert_called_once_with(42, "completed", 1, 1, 1, 0, None)
         finally:
             for p in patches.values():
                 p.stop()
@@ -255,7 +255,7 @@ class TestURLProcessing:
             mocks["fetch"].assert_called_once()
             mocks["get_latest"].assert_not_called()
             mocks["extract_pubs"].assert_not_called()
-            mocks["update_log"].assert_called_once_with(42, "completed", 1, 0, 0)
+            mocks["update_log"].assert_called_once_with(42, "completed", 1, 0, 0, 0, None)
         finally:
             for p in patches.values():
                 p.stop()
@@ -342,7 +342,7 @@ class TestURLProcessing:
             # fetch should be called for url2 even though url1 failed
             assert mocks["fetch"].call_count == 1
             # Log should show completed (per-URL errors are caught)
-            mocks["update_log"].assert_called_once_with(42, "completed", 2, 0, 0)
+            mocks["update_log"].assert_called_once_with(42, "completed", 2, 0, 0, 0, None)
         finally:
             for p in patches.values():
                 p.stop()
@@ -499,3 +499,195 @@ class TestUpdateScrapeLog:
         # prompt_tokens_total=0, completion_tokens_total=0
         assert 0 in params
         assert "kaboom" in params
+
+    @patch("scheduler.Database.execute_query")
+    @patch("scheduler.Database.fetch_one", return_value={
+        "prompt_total": 0, "completion_total": 0,
+    })
+    def test_extraction_errors_parameter(self, mock_fetch, mock_exec):
+        """extraction_errors is written to the scrape_log query."""
+        update_scrape_log(42, "completed", extraction_errors=5)
+        params = mock_exec.call_args[0][1]
+        assert 5 in params
+
+
+# ---------------------------------------------------------------------------
+# 7. Phase separation — fetch before extract
+# ---------------------------------------------------------------------------
+
+class TestPhaseSeparation:
+    """Verify all URLs are fetched before any extraction begins."""
+
+    def test_fetch_runs_before_any_extraction(self):
+        """All fetch calls complete before any extract_publications call."""
+        url_rows = [
+            _make_url_row(url_id=1, url="http://a.com"),
+            _make_url_row(url_id=2, url="http://b.com"),
+        ]
+        patches = _base_patches()
+        patches["get_urls"] = patch(
+            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
+        )
+        patches["fetch"] = patch(
+            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
+        )
+        patches["get_latest"] = patch(
+            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
+        )
+        patches["extract_pubs"] = patch(
+            "scheduler.Publication.extract_publications",
+            return_value=[{"title": "P", "status": "published"}],
+        )
+
+        call_order = []
+
+        mocks = {name: p.start() for name, p in patches.items()}
+        try:
+            orig_fetch = mocks["fetch"].side_effect
+            mocks["fetch"].side_effect = lambda *a, **kw: (call_order.append("fetch"), True)[1]
+            mocks["extract_pubs"].side_effect = lambda *a, **kw: (call_order.append("extract"), [{"title": "P"}])[1]
+
+            run_scrape_job()
+
+            fetch_indices = [i for i, c in enumerate(call_order) if c == "fetch"]
+            extract_indices = [i for i, c in enumerate(call_order) if c == "extract"]
+            assert len(fetch_indices) > 0
+            assert len(extract_indices) > 0
+            assert max(fetch_indices) < min(extract_indices)
+        finally:
+            for p in patches.values():
+                p.stop()
+
+    def test_all_urls_fetched_when_extraction_fails(self):
+        """All URLs are fetched even when extraction returns empty for all."""
+        url_rows = [
+            _make_url_row(url_id=i, url=f"http://r{i}.com")
+            for i in range(1, 6)
+        ]
+        patches = _base_patches()
+        patches["get_urls"] = patch(
+            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
+        )
+        patches["fetch"] = patch(
+            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
+        )
+        patches["get_latest"] = patch(
+            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
+        )
+        mocks = {name: p.start() for name, p in patches.items()}
+        try:
+            run_scrape_job()
+            assert mocks["fetch"].call_count == 5
+        finally:
+            for p in patches.values():
+                p.stop()
+
+
+# ---------------------------------------------------------------------------
+# 8. Extraction circuit breaker
+# ---------------------------------------------------------------------------
+
+class TestExtractionCircuitBreaker:
+    """Verify circuit breaker stops extraction after consecutive failures."""
+
+    def test_stops_after_threshold_consecutive_failures(self):
+        url_rows = [
+            _make_url_row(url_id=i, url=f"http://r{i}.com")
+            for i in range(1, 21)
+        ]
+        patches = _base_patches()
+        patches["get_urls"] = patch(
+            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
+        )
+        patches["fetch"] = patch(
+            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
+        )
+        patches["get_latest"] = patch(
+            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
+        )
+        # extract always returns empty (quota failure)
+        patches["extract_pubs"] = patch(
+            "scheduler.Publication.extract_publications", return_value=[],
+        )
+        mocks = {name: p.start() for name, p in patches.items()}
+        try:
+            from scheduler import _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD
+            run_scrape_job()
+
+            # All 20 fetched
+            assert mocks["fetch"].call_count == 20
+            # Extraction stops at threshold
+            assert mocks["extract_pubs"].call_count == _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD
+        finally:
+            for p in patches.values():
+                p.stop()
+
+    def test_resets_on_successful_extraction(self):
+        """A successful extraction resets the consecutive failure counter."""
+        url_rows = [
+            _make_url_row(url_id=i, url=f"http://r{i}.com")
+            for i in range(1, 21)
+        ]
+        patches = _base_patches()
+        patches["get_urls"] = patch(
+            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
+        )
+        patches["fetch"] = patch(
+            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
+        )
+        patches["get_latest"] = patch(
+            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
+        )
+
+        # Fail 5 times, succeed on 6th, repeat — never hits 10 consecutive
+        call_count = [0]
+        def alternating(*a, **kw):
+            call_count[0] += 1
+            if call_count[0] % 6 == 0:
+                return [{"title": "Paper", "status": "published"}]
+            return []
+
+        patches["extract_pubs"] = patch(
+            "scheduler.Publication.extract_publications", side_effect=alternating,
+        )
+        mocks = {name: p.start() for name, p in patches.items()}
+        try:
+            run_scrape_job()
+            # All 20 extracted (no circuit break)
+            assert mocks["extract_pubs"].call_count == 20
+        finally:
+            for p in patches.values():
+                p.stop()
+
+    def test_records_error_message_when_tripped(self):
+        """Circuit breaker sets error_message on scrape_log."""
+        url_rows = [
+            _make_url_row(url_id=i, url=f"http://r{i}.com")
+            for i in range(1, 15)
+        ]
+        patches = _base_patches()
+        patches["get_urls"] = patch(
+            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
+        )
+        patches["fetch"] = patch(
+            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
+        )
+        patches["get_latest"] = patch(
+            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
+        )
+        patches["extract_pubs"] = patch(
+            "scheduler.Publication.extract_publications", return_value=[],
+        )
+        mocks = {name: p.start() for name, p in patches.items()}
+        try:
+            from scheduler import _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD
+            run_scrape_job()
+
+            mocks["update_log"].assert_called_once()
+            args = mocks["update_log"].call_args[0]
+            assert args[1] == "completed"  # status still completed (fetch did finish)
+            assert args[5] == _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD  # extraction_errors
+            assert "circuit-breaker" in args[6].lower()  # error_message
+        finally:
+            for p in patches.values():
+                p.stop()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -44,9 +44,8 @@ def _base_patches():
         "extract_pubs": patch("scheduler.Publication.extract_publications", return_value=[]),
         "save_pubs": patch("scheduler.Publication.save_publications"),
         "match_links": patch("scheduler.match_and_save_paper_links"),
-        "title_hash": patch("scheduler.Database.compute_title_hash", return_value="abc123"),
         "fetch_one": patch("scheduler.Database.fetch_one", return_value=None),
-        "paper_snap": patch("scheduler.Database.append_paper_snapshot"),
+        "paper_snap": patch("scheduler.append_snapshots_for_pubs"),
         "researcher_snap": patch("scheduler.Database.append_researcher_snapshot"),
         "reconcile_renames": patch("scheduler.reconcile_title_renames"),
     }
@@ -94,9 +93,6 @@ class TestRunScrapeJobHappyPath:
         patches["extract_pubs"] = patch(
             "scheduler.Publication.extract_publications", return_value=pubs
         )
-        patches["fetch_one"] = patch(
-            "scheduler.Database.fetch_one", return_value={"id": 99}
-        )
 
         mocks = {name: p.start() for name, p in patches.items()}
         try:
@@ -106,7 +102,7 @@ class TestRunScrapeJobHappyPath:
             mocks["save_pubs"].assert_called_once_with(
                 url_row["url"], pubs, is_seed=True,
             )
-            mocks["paper_snap"].assert_called_once()
+            mocks["paper_snap"].assert_called_once_with(pubs, url_row["url"])
             mocks["update_log"].assert_called_once_with(42, "completed", 1, 1, 1)
         finally:
             for p in patches.values():
@@ -429,8 +425,8 @@ class TestURLProcessing:
             for p in patches.values():
                 p.stop()
 
-    def test_paper_not_found_skips_snapshot(self):
-        """If paper lookup returns None, paper snapshot is skipped."""
+    def test_snapshots_called_with_pubs(self):
+        """append_snapshots_for_pubs is called with extracted publications."""
         url_row = _make_url_row()
         pubs = [{"title": "Ghost Paper", "status": "published"}]
         patches = _base_patches()
@@ -446,16 +442,11 @@ class TestURLProcessing:
         patches["extract_pubs"] = patch(
             "scheduler.Publication.extract_publications", return_value=pubs
         )
-        # Paper not found in DB
-        patches["fetch_one"] = patch(
-            "scheduler.Database.fetch_one", return_value=None
-        )
         mocks = {name: p.start() for name, p in patches.items()}
         try:
             run_scrape_job()
 
-            mocks["title_hash"].assert_called_once_with("Ghost Paper")
-            mocks["paper_snap"].assert_not_called()
+            mocks["paper_snap"].assert_called_once_with(pubs, url_row["url"])
         finally:
             for p in patches.values():
                 p.stop()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -700,28 +700,22 @@ class TestExtractionCircuitBreaker:
 class TestStaleLogCleanup:
     """Verify stale running scrape_log entries get cleaned up."""
 
-    @patch("scheduler.Database.fetch_all")
     @patch("scheduler.Database.execute_query")
-    def test_marks_old_running_entries_as_failed(self, mock_exec, mock_fetch_all):
-        mock_fetch_all.return_value = [
-            {"id": 6, "started_at": "2026-03-19 22:26:31"},
-            {"id": 9, "started_at": "2026-03-23 15:13:20"},
-        ]
+    def test_marks_old_running_entries_as_failed(self, mock_exec):
+        mock_exec.return_value = 2
 
         _cleanup_stale_scrape_logs()
 
-        assert mock_exec.call_count == 2
-        for c in mock_exec.call_args_list:
-            query = c[0][0]
-            params = c[0][1]
-            assert "UPDATE scrape_log" in query
-            assert "failed" in params
+        mock_exec.assert_called_once()
+        query = mock_exec.call_args[0][0]
+        assert "UPDATE scrape_log" in query
+        assert "status = 'failed'" in query
+        assert "INTERVAL %s HOUR" in query
 
-    @patch("scheduler.Database.fetch_all")
     @patch("scheduler.Database.execute_query")
-    def test_skips_when_none_stale(self, mock_exec, mock_fetch_all):
-        mock_fetch_all.return_value = []
+    def test_skips_when_none_stale(self, mock_exec):
+        mock_exec.return_value = 0
 
         _cleanup_stale_scrape_logs()
 
-        mock_exec.assert_not_called()
+        mock_exec.assert_called_once()


### PR DESCRIPTION
## Summary
- Split `run_scrape_job()` into two sequential phases: **fetch all HTML first**, then **extract from changed URLs**. Fetch always completes even when the LLM provider is down or quota-exhausted.
- Added an **extraction circuit breaker** — after 10 consecutive empty extraction results (e.g. quota errors), extraction stops early. Fetched HTML is preserved for the next run via `content_hash ≠ extracted_hash`.
- Added **stale scrape_log cleanup** on scheduler start — entries stuck in `'running'` for >24h are auto-marked as `'failed'`.
- Added `extraction_errors` column to `scrape_log` for observability.

## Motivation
When OpenAI quota was exhausted, the interleaved fetch+extract loop caused the entire scrape job to stall — each URL's extraction attempt added timeouts/retries before moving to the next URL, preventing the job from completing within the scheduler interval. This left HTML unfetched and the scheduler permanently blocked.

## Test plan
- [x] 8 new tests covering phase separation, circuit breaker (threshold, reset-on-success, error recording), and stale cleanup
- [x] All 15 existing scheduler tests updated for new `extraction_errors` parameter
- [x] Full suite: 715 tests passing (was 707)

🤖 Generated with [Claude Code](https://claude.com/claude-code)