### PR TITLE
feat: continuous enrichment background worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ OPENALEX_API_KEY=
 OPENALEX_MAILTO=your@email.com
 OPENALEX_DAILY_BUDGET=1000
 
+# Enrichment worker (runs continuously in the API process)
+ENRICHMENT_WORKER_ENABLED=false
+
 # Production deployment
 # FRONTEND_URL=https://your-app.vercel.app    # Required in prod for CORS
 # WEB_CONCURRENCY=2                           # Gunicorn workers (default 2)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ make seed                 # Create tables + run migrations (idempotent)
 make reset-db             # Drop and recreate database from scratch
 
 # Scraping pipeline
-make scrape               # Full pipeline: fetch HTML → LLM extract → save → link match → enrich
+make scrape               # Full pipeline: fetch HTML → LLM extract → save → link match
 make fetch                # Stage 1: Download HTML from researcher URLs (hash-based change detection)
 make batch-submit         # Stage 2: Submit changed URLs to Gemini Batch API for extraction
 make batch-check          # Stage 3: Process completed batch results → save papers, snapshots, links
@@ -57,7 +57,8 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build  #
 1. **Fetch phase** (all URLs): Download HTML for all researcher URLs, skip unchanged (content hash). Collects list of changed URLs.
 2. **Extract phase** (changed URLs only): LLM extracts publications from changed pages, saves to `papers`. Includes link matching, title reconciliation, and paper snapshots.
 3. **Draft URL validation**: HEAD-request validation of `draft_url` fields
-4. **Enrichment phase** (after releasing scrape lock): Enrich unenriched papers via OpenAlex — DOI lookup first (from `paper_links`), title search fallback (published papers only)
+
+**Enrichment worker:** When `ENRICHMENT_WORKER_ENABLED=true`, a background thread in the API process continuously enriches unenriched papers via OpenAlex. Polls every 5 minutes, processes batches of 50, respects the daily budget. Backs off to 10-minute sleep after 5 consecutive failures. In local dev (worker disabled), run `make enrich` manually after scraping.
 
 **Extraction circuit breaker:** If 10 consecutive URLs return empty extraction results (e.g. LLM quota exhausted), the extraction phase stops early. Fetched HTML is preserved — extraction will resume on the next run for URLs where `content_hash ≠ extracted_hash`. The `scrape_log.extraction_errors` column tracks how many URLs failed extraction per run.
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -460,10 +460,14 @@ def start_scheduler() -> None:
         logger.info("SCRAPE_ON_STARTUP is true, triggering immediate scrape in background")
         threading.Thread(target=run_scrape_job, name="startup-scrape").start()
 
+    if ENRICHMENT_WORKER_ENABLED:
+        start_enrichment_worker()
+
 
 def shutdown_scheduler() -> None:
     """Shut down the scheduler gracefully, waiting for any running job to complete."""
     global _scheduler, _scheduler_lock_conn
+    stop_enrichment_worker()
     if _scheduler is not None:
         _scheduler.shutdown(wait=True)
         _scheduler = None

--- a/scheduler.py
+++ b/scheduler.py
@@ -150,15 +150,6 @@ def _validate_draft_urls() -> None:
             logger.error(f"Error validating draft URL for paper {paper_id}: {e}")
 
 
-def _enrich_with_openalex() -> None:
-    """Enrich newly discovered publications with OpenAlex metadata."""
-    try:
-        from openalex import enrich_new_publications
-        enrich_new_publications()
-    except Exception as e:
-        logger.error("OpenAlex enrichment failed: %s: %s", type(e).__name__, e)
-
-
 _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD = 10
 
 
@@ -337,11 +328,6 @@ def run_scrape_job() -> None:
     finally:
         _release_db_lock(lock_conn)
         _lock_conn = None
-
-    t0 = time.time()
-    _enrich_with_openalex()
-    enrich_s = time.time() - t0
-    logger.info(f"OpenAlex enrichment: {enrich_s:.1f}s")
 
     t0 = time.time()
     try:

--- a/scheduler.py
+++ b/scheduler.py
@@ -14,6 +14,7 @@ from researcher import Researcher
 from html_fetcher import HTMLFetcher
 from publication import Publication, reconcile_title_renames, append_snapshots_for_pubs
 from link_extractor import match_and_save_paper_links
+from openalex import enrich_new_publications
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,14 @@ def is_scrape_running() -> bool:
 
 SCRAPE_INTERVAL_HOURS = int(os.environ.get('SCRAPE_INTERVAL_HOURS', '24'))
 SCRAPE_ON_STARTUP = os.environ.get('SCRAPE_ON_STARTUP', 'false').lower() == 'true'
+ENRICHMENT_WORKER_ENABLED = os.environ.get('ENRICHMENT_WORKER_ENABLED', 'false').lower() == 'true'
+_ENRICHMENT_IDLE_SECONDS = 300  # 5 minutes
+_ENRICHMENT_BATCH_SIZE = 50
+_ENRICHMENT_BACKOFF_THRESHOLD = 5
+_ENRICHMENT_BACKOFF_SECONDS = 600  # 10 minutes
+
+_enrichment_thread = None
+_enrichment_stop_event = threading.Event()
 
 
 def create_scrape_log() -> int:
@@ -344,6 +353,62 @@ def _handle_sigterm(signum: int, frame: object) -> None:
     Waits for any running scrape job to complete before exiting."""
     logger.info("Received signal %s, shutting down scheduler gracefully...", signum)
     shutdown_scheduler()
+
+
+def _enrichment_worker_loop() -> None:
+    """Continuously enrich unenriched papers until stop event is set."""
+    logger.info("Enrichment worker started")
+    consecutive_failures = 0
+
+    while not _enrichment_stop_event.is_set():
+        try:
+            enriched = enrich_new_publications(limit=_ENRICHMENT_BATCH_SIZE)
+            consecutive_failures = 0
+            if enriched:
+                logger.info("Enrichment cycle: %d papers enriched", enriched)
+            else:
+                logger.info("Enrichment cycle: no papers to enrich, sleeping %ds", _ENRICHMENT_IDLE_SECONDS)
+        except Exception as e:
+            consecutive_failures += 1
+            logger.error("Enrichment cycle failed (%d consecutive): %s: %s",
+                         consecutive_failures, type(e).__name__, e)
+
+        if consecutive_failures >= _ENRICHMENT_BACKOFF_THRESHOLD:
+            logger.warning("Enrichment backing off for %ds after %d consecutive failures",
+                           _ENRICHMENT_BACKOFF_SECONDS, consecutive_failures)
+            _enrichment_stop_event.wait(_ENRICHMENT_BACKOFF_SECONDS)
+        else:
+            _enrichment_stop_event.wait(_ENRICHMENT_IDLE_SECONDS)
+
+    logger.info("Enrichment worker stopped")
+
+
+def start_enrichment_worker() -> None:
+    """Start the enrichment background worker thread."""
+    global _enrichment_thread
+    if _enrichment_thread is not None and _enrichment_thread.is_alive():
+        logger.warning("Enrichment worker already running")
+        return
+
+    _enrichment_stop_event.clear()
+    _enrichment_thread = threading.Thread(
+        target=_enrichment_worker_loop,
+        name="enrichment-worker",
+        daemon=True,
+    )
+    _enrichment_thread.start()
+    logger.info("Enrichment worker thread started")
+
+
+def stop_enrichment_worker() -> None:
+    """Stop the enrichment worker gracefully."""
+    global _enrichment_thread
+    if _enrichment_thread is None:
+        return
+    _enrichment_stop_event.set()
+    _enrichment_thread.join(timeout=30)
+    _enrichment_thread = None
+    logger.info("Enrichment worker thread stopped")
 
 
 def start_scheduler() -> None:

--- a/scheduler.py
+++ b/scheduler.py
@@ -14,8 +14,6 @@ from researcher import Researcher
 from html_fetcher import HTMLFetcher
 from publication import Publication, reconcile_title_renames, append_snapshots_for_pubs
 from link_extractor import match_and_save_paper_links
-from openalex import enrich_new_publications
-
 logger = logging.getLogger(__name__)
 
 _LOCK_NAME = 'econ_newsfeed_scrape'
@@ -357,8 +355,11 @@ def _handle_sigterm(signum: int, frame: object) -> None:
 
 def _enrichment_worker_loop() -> None:
     """Continuously enrich unenriched papers until stop event is set."""
+    from openalex import enrich_new_publications
+
     logger.info("Enrichment worker started")
     consecutive_failures = 0
+    enriched = 0
 
     while not _enrichment_stop_event.is_set():
         try:
@@ -369,6 +370,7 @@ def _enrichment_worker_loop() -> None:
             else:
                 logger.info("Enrichment cycle: no papers to enrich, sleeping %ds", _ENRICHMENT_IDLE_SECONDS)
         except Exception as e:
+            enriched = 0
             consecutive_failures += 1
             logger.error("Enrichment cycle failed (%d consecutive): %s: %s",
                          consecutive_failures, type(e).__name__, e)
@@ -377,7 +379,7 @@ def _enrichment_worker_loop() -> None:
             logger.warning("Enrichment backing off for %ds after %d consecutive failures",
                            _ENRICHMENT_BACKOFF_SECONDS, consecutive_failures)
             _enrichment_stop_event.wait(_ENRICHMENT_BACKOFF_SECONDS)
-        else:
+        elif enriched == 0:
             _enrichment_stop_event.wait(_ENRICHMENT_IDLE_SECONDS)
 
     logger.info("Enrichment worker stopped")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -869,3 +869,76 @@ class TestStartStopEnrichmentWorker:
         import scheduler
         scheduler._enrichment_thread = None
         stop_enrichment_worker()  # should not raise
+
+
+class TestSchedulerStartsEnrichmentWorker:
+    """Enrichment worker starts/stops with the scheduler when enabled."""
+
+    def test_starts_enrichment_worker_when_enabled(self):
+        """start_scheduler starts the enrichment worker if ENRICHMENT_WORKER_ENABLED=true."""
+        import scheduler
+
+        with patch("scheduler.mysql.connector.connect") as mock_connect, \
+             patch("scheduler._cleanup_stale_scrape_logs"), \
+             patch("scheduler.BackgroundScheduler") as mock_bg, \
+             patch("scheduler.start_enrichment_worker") as mock_start_worker, \
+             patch("scheduler.signal.signal"), \
+             patch.object(scheduler, 'ENRICHMENT_WORKER_ENABLED', True), \
+             patch.object(scheduler, '_scheduler', None), \
+             patch.object(scheduler, '_scheduler_lock_conn', None):
+
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_cursor.fetchone.return_value = (1,)
+            mock_conn.cursor.return_value = mock_cursor
+            mock_connect.return_value = mock_conn
+
+            from scheduler import start_scheduler
+            start_scheduler()
+
+            mock_start_worker.assert_called_once()
+
+            # Cleanup
+            scheduler._scheduler = None
+            scheduler._scheduler_lock_conn = None
+
+    def test_skips_enrichment_worker_when_disabled(self):
+        """start_scheduler does NOT start enrichment worker if ENRICHMENT_WORKER_ENABLED=false."""
+        import scheduler
+
+        with patch("scheduler.mysql.connector.connect") as mock_connect, \
+             patch("scheduler._cleanup_stale_scrape_logs"), \
+             patch("scheduler.BackgroundScheduler") as mock_bg, \
+             patch("scheduler.start_enrichment_worker") as mock_start_worker, \
+             patch("scheduler.signal.signal"), \
+             patch.object(scheduler, 'ENRICHMENT_WORKER_ENABLED', False), \
+             patch.object(scheduler, '_scheduler', None), \
+             patch.object(scheduler, '_scheduler_lock_conn', None):
+
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_cursor.fetchone.return_value = (1,)
+            mock_conn.cursor.return_value = mock_cursor
+            mock_connect.return_value = mock_conn
+
+            from scheduler import start_scheduler
+            start_scheduler()
+
+            mock_start_worker.assert_not_called()
+
+            # Cleanup
+            scheduler._scheduler = None
+            scheduler._scheduler_lock_conn = None
+
+    def test_shutdown_stops_enrichment_worker(self):
+        """shutdown_scheduler also stops the enrichment worker."""
+        import scheduler
+
+        with patch("scheduler.stop_enrichment_worker") as mock_stop_worker:
+            scheduler._scheduler = MagicMock()
+            scheduler._scheduler_lock_conn = MagicMock()
+
+            from scheduler import shutdown_scheduler
+            shutdown_scheduler()
+
+            mock_stop_worker.assert_called_once()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -74,6 +74,18 @@ class TestRunScrapeJobHappyPath:
             for p in patches.values():
                 p.stop()
 
+    def test_scrape_does_not_call_enrichment(self):
+        """run_scrape_job no longer triggers OpenAlex enrichment."""
+        patches = _base_patches()
+        mocks = {name: p.start() for name, p in patches.items()}
+        try:
+            with patch("openalex.enrich_new_publications") as mock_enrich:
+                run_scrape_job()
+                mock_enrich.assert_not_called()
+        finally:
+            for p in patches.values():
+                p.stop()
+
     def test_happy_path_with_changed_url(self):
         """One URL changes, publications extracted and saved, log reflects counts."""
         url_row = _make_url_row()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -9,7 +9,11 @@ from unittest.mock import MagicMock, patch, call
 import pytest
 
 import scheduler
-from scheduler import run_scrape_job, create_scrape_log, update_scrape_log, _cleanup_stale_scrape_logs
+from scheduler import (
+    run_scrape_job, create_scrape_log, update_scrape_log,
+    _cleanup_stale_scrape_logs,
+    _enrichment_worker_loop, start_enrichment_worker, stop_enrichment_worker,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -731,3 +735,137 @@ class TestStaleLogCleanup:
         _cleanup_stale_scrape_logs()
 
         mock_exec.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 10. Enrichment worker
+# ---------------------------------------------------------------------------
+
+class TestEnrichmentWorkerLoop:
+    """Tests for the continuous enrichment background worker."""
+
+    def setup_method(self):
+        """Clear the stop event before each test."""
+        import scheduler
+        scheduler._enrichment_stop_event.clear()
+
+    def test_enriches_and_sleeps_when_papers_found(self):
+        """Worker calls enrich_new_publications, then sleeps IDLE interval."""
+        call_count = [0]
+        def enrich_then_stop(limit):
+            call_count[0] += 1
+            if call_count[0] >= 2:
+                import scheduler
+                scheduler._enrichment_stop_event.set()
+            return 5
+
+        with patch("scheduler.enrich_new_publications", side_effect=enrich_then_stop) as mock_enrich, \
+             patch("scheduler._ENRICHMENT_IDLE_SECONDS", 0), \
+             patch("scheduler._ENRICHMENT_BACKOFF_SECONDS", 0):
+            _enrichment_worker_loop()
+
+        assert mock_enrich.call_count == 2
+
+    def test_sleeps_idle_interval_when_no_papers(self):
+        """Worker sleeps the idle interval when no papers to enrich."""
+        call_count = [0]
+        def enrich_then_stop(limit):
+            call_count[0] += 1
+            if call_count[0] >= 1:
+                import scheduler
+                scheduler._enrichment_stop_event.set()
+            return 0
+
+        with patch("scheduler.enrich_new_publications", side_effect=enrich_then_stop), \
+             patch("scheduler._ENRICHMENT_IDLE_SECONDS", 0), \
+             patch("scheduler._ENRICHMENT_BACKOFF_SECONDS", 0):
+            _enrichment_worker_loop()
+
+    def test_backs_off_on_consecutive_errors(self):
+        """Worker extends sleep after consecutive failures."""
+        call_count = [0]
+        def fail_then_stop(limit):
+            call_count[0] += 1
+            if call_count[0] >= 6:
+                import scheduler
+                scheduler._enrichment_stop_event.set()
+                return 0
+            raise RuntimeError("OpenAlex down")
+
+        with patch("scheduler.enrich_new_publications", side_effect=fail_then_stop) as mock_enrich, \
+             patch("scheduler._ENRICHMENT_BACKOFF_THRESHOLD", 3), \
+             patch("scheduler._ENRICHMENT_IDLE_SECONDS", 0), \
+             patch("scheduler._ENRICHMENT_BACKOFF_SECONDS", 0):
+            _enrichment_worker_loop()
+
+        assert mock_enrich.call_count == 6
+
+    def test_resets_backoff_on_success(self):
+        """Consecutive failure count resets after a successful enrichment."""
+        call_count = [0]
+        def fail_succeed_stop(limit):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                raise RuntimeError("transient error")
+            if call_count[0] == 3:
+                return 5
+            if call_count[0] <= 5:
+                raise RuntimeError("transient error again")
+            import scheduler
+            scheduler._enrichment_stop_event.set()
+            return 0
+
+        with patch("scheduler.enrich_new_publications", side_effect=fail_succeed_stop), \
+             patch("scheduler._ENRICHMENT_IDLE_SECONDS", 0), \
+             patch("scheduler._ENRICHMENT_BACKOFF_SECONDS", 0):
+            _enrichment_worker_loop()
+
+
+class TestStartStopEnrichmentWorker:
+    """Tests for starting and stopping the enrichment worker thread."""
+
+    def test_start_creates_daemon_thread(self):
+        """start_enrichment_worker creates a daemon thread."""
+        with patch("scheduler.threading.Thread") as mock_thread_cls:
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            start_enrichment_worker()
+
+            mock_thread_cls.assert_called_once()
+            assert mock_thread_cls.call_args[1]["daemon"] is True
+            mock_thread.start.assert_called_once()
+
+            import scheduler
+            scheduler._enrichment_thread = None
+            scheduler._enrichment_stop_event.clear()
+
+    def test_start_is_idempotent(self):
+        """Calling start twice doesn't create a second thread."""
+        import scheduler
+        scheduler._enrichment_thread = MagicMock(is_alive=MagicMock(return_value=True))
+        try:
+            with patch("scheduler.threading.Thread") as mock_thread_cls:
+                start_enrichment_worker()
+                mock_thread_cls.assert_not_called()
+        finally:
+            scheduler._enrichment_thread = None
+
+    def test_stop_sets_event_and_joins(self):
+        """stop_enrichment_worker signals the thread and waits for it."""
+        import scheduler
+        mock_thread = MagicMock()
+        scheduler._enrichment_thread = mock_thread
+        scheduler._enrichment_stop_event.clear()
+
+        stop_enrichment_worker()
+
+        assert scheduler._enrichment_stop_event.is_set()
+        mock_thread.join.assert_called_once_with(timeout=30)
+        assert scheduler._enrichment_thread is None
+
+    def test_stop_when_not_running_is_noop(self):
+        """stop_enrichment_worker does nothing if no thread is running."""
+        import scheduler
+        scheduler._enrichment_thread = None
+        stop_enrichment_worker()  # should not raise

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -759,7 +759,7 @@ class TestEnrichmentWorkerLoop:
                 scheduler._enrichment_stop_event.set()
             return 5
 
-        with patch("scheduler.enrich_new_publications", side_effect=enrich_then_stop) as mock_enrich, \
+        with patch("openalex.enrich_new_publications", side_effect=enrich_then_stop) as mock_enrich, \
              patch("scheduler._ENRICHMENT_IDLE_SECONDS", 0), \
              patch("scheduler._ENRICHMENT_BACKOFF_SECONDS", 0):
             _enrichment_worker_loop()
@@ -776,7 +776,7 @@ class TestEnrichmentWorkerLoop:
                 scheduler._enrichment_stop_event.set()
             return 0
 
-        with patch("scheduler.enrich_new_publications", side_effect=enrich_then_stop), \
+        with patch("openalex.enrich_new_publications", side_effect=enrich_then_stop), \
              patch("scheduler._ENRICHMENT_IDLE_SECONDS", 0), \
              patch("scheduler._ENRICHMENT_BACKOFF_SECONDS", 0):
             _enrichment_worker_loop()
@@ -792,7 +792,7 @@ class TestEnrichmentWorkerLoop:
                 return 0
             raise RuntimeError("OpenAlex down")
 
-        with patch("scheduler.enrich_new_publications", side_effect=fail_then_stop) as mock_enrich, \
+        with patch("openalex.enrich_new_publications", side_effect=fail_then_stop) as mock_enrich, \
              patch("scheduler._ENRICHMENT_BACKOFF_THRESHOLD", 3), \
              patch("scheduler._ENRICHMENT_IDLE_SECONDS", 0), \
              patch("scheduler._ENRICHMENT_BACKOFF_SECONDS", 0):
@@ -815,7 +815,7 @@ class TestEnrichmentWorkerLoop:
             scheduler._enrichment_stop_event.set()
             return 0
 
-        with patch("scheduler.enrich_new_publications", side_effect=fail_succeed_stop), \
+        with patch("openalex.enrich_new_publications", side_effect=fail_succeed_stop), \
              patch("scheduler._ENRICHMENT_IDLE_SECONDS", 0), \
              patch("scheduler._ENRICHMENT_BACKOFF_SECONDS", 0):
             _enrichment_worker_loop()
@@ -823,6 +823,11 @@ class TestEnrichmentWorkerLoop:
 
 class TestStartStopEnrichmentWorker:
     """Tests for starting and stopping the enrichment worker thread."""
+
+    def teardown_method(self):
+        import scheduler
+        scheduler._enrichment_thread = None
+        scheduler._enrichment_stop_event.clear()
 
     def test_start_creates_daemon_thread(self):
         """start_enrichment_worker creates a daemon thread."""
@@ -836,27 +841,19 @@ class TestStartStopEnrichmentWorker:
             assert mock_thread_cls.call_args[1]["daemon"] is True
             mock_thread.start.assert_called_once()
 
-            import scheduler
-            scheduler._enrichment_thread = None
-            scheduler._enrichment_stop_event.clear()
-
     def test_start_is_idempotent(self):
         """Calling start twice doesn't create a second thread."""
         import scheduler
         scheduler._enrichment_thread = MagicMock(is_alive=MagicMock(return_value=True))
-        try:
-            with patch("scheduler.threading.Thread") as mock_thread_cls:
-                start_enrichment_worker()
-                mock_thread_cls.assert_not_called()
-        finally:
-            scheduler._enrichment_thread = None
+        with patch("scheduler.threading.Thread") as mock_thread_cls:
+            start_enrichment_worker()
+            mock_thread_cls.assert_not_called()
 
     def test_stop_sets_event_and_joins(self):
         """stop_enrichment_worker signals the thread and waits for it."""
         import scheduler
         mock_thread = MagicMock()
         scheduler._enrichment_thread = mock_thread
-        scheduler._enrichment_stop_event.clear()
 
         stop_enrichment_worker()
 
@@ -873,6 +870,11 @@ class TestStartStopEnrichmentWorker:
 
 class TestSchedulerStartsEnrichmentWorker:
     """Enrichment worker starts/stops with the scheduler when enabled."""
+
+    def teardown_method(self):
+        import scheduler
+        scheduler._scheduler = None
+        scheduler._scheduler_lock_conn = None
 
     def test_starts_enrichment_worker_when_enabled(self):
         """start_scheduler starts the enrichment worker if ENRICHMENT_WORKER_ENABLED=true."""
@@ -898,10 +900,6 @@ class TestSchedulerStartsEnrichmentWorker:
 
             mock_start_worker.assert_called_once()
 
-            # Cleanup
-            scheduler._scheduler = None
-            scheduler._scheduler_lock_conn = None
-
     def test_skips_enrichment_worker_when_disabled(self):
         """start_scheduler does NOT start enrichment worker if ENRICHMENT_WORKER_ENABLED=false."""
         import scheduler
@@ -925,10 +923,6 @@ class TestSchedulerStartsEnrichmentWorker:
             start_scheduler()
 
             mock_start_worker.assert_not_called()
-
-            # Cleanup
-            scheduler._scheduler = None
-            scheduler._scheduler_lock_conn = None
 
     def test_shutdown_stops_enrichment_worker(self):
         """shutdown_scheduler also stops the enrichment worker."""


### PR DESCRIPTION
## Summary

- Adds a continuously running background worker thread that enriches unenriched papers via OpenAlex (polls every 5 minutes, batches of 50, respects daily budget)
- Removes enrichment from the scrape pipeline — worker owns all enrichment
- Gated by `ENRICHMENT_WORKER_ENABLED` env var (off by default); starts/stops with the scheduler

## Design

See [ADR: enrichment owned by background worker](docs/adr/0001-enrichment-owned-by-background-worker.md)

- Daemon thread with `threading.Event.wait()` for graceful shutdown
- Backs off to 10-minute sleep after 5 consecutive failures
- In local dev (worker disabled), run `make enrich` manually after scraping

## Test plan

- [x] 12 new scheduler tests covering worker loop, start/stop lifecycle, and scheduler integration
- [x] 39/39 scheduler tests passing
- [x] 743/743 full Python test suite passing
- [ ] Deploy to staging with `ENRICHMENT_WORKER_ENABLED=true`, verify worker logs in `docker compose logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)