### PR TITLE
fix: repair 4 failing tests on main CI

### DIFF
--- a/tests/test_batch_pipeline.py
+++ b/tests/test_batch_pipeline.py
@@ -71,9 +71,10 @@ class TestBatchCheckFileDownload(unittest.TestCase):
         # OpenAI SDK: batch is completed with an output file
         mock_openai = MagicMock()
         mock_batch_obj = MagicMock()
+        mock_batch_obj.id = "batch_abc"
         mock_batch_obj.status = "completed"
         mock_batch_obj.output_file_id = "files/output123"
-        mock_openai.batches.retrieve.return_value = mock_batch_obj
+        mock_openai.batches.list.return_value = [mock_batch_obj]
 
         # genai SDK: file download returns JSONL with one valid result
         result_line = json_module.dumps({
@@ -117,8 +118,8 @@ class TestBatchCheckFileDownload(unittest.TestCase):
         # genai SDK used for download
         mock_genai.files.download.assert_called_once_with(file="files/output123")
 
-        # OpenAI SDK used for batch retrieve
-        mock_openai.batches.retrieve.assert_called_once_with("batch_abc")
+        # OpenAI SDK used to list pending batches
+        mock_openai.batches.list.assert_called_once_with(limit=100)
 
 
 class TestBatchValidationGap(unittest.TestCase):

--- a/tests/test_encoding_integration.py
+++ b/tests/test_encoding_integration.py
@@ -18,8 +18,9 @@ import pytest
 class TestPublicationEncodingGuard:
     """Verify save_publications passes text through encoding guard."""
 
-    @patch("publication.Database")
-    def test_mojibake_title_is_fixed_before_insert(self, mock_db):
+    @patch("feed_events.Database")
+    @patch("paper_saver.Database")
+    def test_mojibake_title_is_fixed_before_insert(self, mock_db, mock_events_db):
         """A paper with mojibake in title should be cleaned before DB insert."""
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
@@ -30,6 +31,7 @@ class TestPublicationEncodingGuard:
         mock_conn.__enter__ = lambda s: s
         mock_conn.__exit__ = MagicMock(return_value=False)
         mock_db.get_connection.return_value = mock_conn
+        mock_events_db.get_connection.return_value = mock_conn
 
         from publication import Publication
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -85,7 +85,8 @@ class TestExtractJson:
         assert result.usage.total_tokens == 15
 
     @patch("llm_client.get_client")
-    def test_uses_json_schema_response_format(self, mock_get_client):
+    def test_uses_json_schema_response_format(self, mock_get_client, monkeypatch):
+        monkeypatch.setenv("LLM_MODEL", "gemma-4-31b-it")
         import llm_client
         mock_client = mock_get_client.return_value
         mock_client.chat.completions.create.return_value = _mock_completion('{"items":[]}')

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -294,9 +294,7 @@ class TestRateLimitErrorEnvelope:
         mock_limit.limit = "60 per 1 minute"
         exc = RateLimitExceeded(mock_limit)
 
-        response = asyncio.get_event_loop().run_until_complete(
-            _rate_limit_handler(req, exc)
-        )
+        response = asyncio.run(_rate_limit_handler(req, exc))
         import json
         body = json.loads(response.body)
         assert response.status_code == 429


### PR DESCRIPTION
Main's CI has been red since the recent refactors and the #137 merge. This fixes all four failing tests — test changes only, no production code:

- **test_batch_pipeline::test_uses_genai_for_download** — mocked `batches.retrieve`, but `batch_check` now indexes `client.batches.list()`; the mock batch was never found.
- **test_encoding_integration::test_mojibake_title_is_fixed_before_insert** — patched `publication.Database`, but persistence moved to `paper_saver.py`/`feed_events.py` in the PaperSaver refactor, so the test hit a real DB connection.
- **test_security::test_rate_limit_response_uses_error_envelope** — used deprecated `asyncio.get_event_loop()`, which breaks when anyio-based tests (added in #137) run earlier in the suite.
- **test_llm_client::test_uses_json_schema_response_format** — asserted the hardcoded default model, but ci.yml sets `LLM_MODEL=gemini-2.5-flash`; now pins the env var via monkeypatch.

Verified locally: 849 passed with `LLM_MODEL=gemini-2.5-flash` (mirroring CI env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)