### PR TITLE
feat: continuous extraction background worker (free-tier Gemma)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@
 !openalex.py
 !llm_client.py
 !publication.py
+!extraction.py
 !researcher.py
 !encoding_guard.py
 !feed_events.py

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ OPENALEX_DAILY_BUDGET=1000
 # Enrichment worker (runs continuously in the API process)
 ENRICHMENT_WORKER_ENABLED=false
 
+# Extraction worker (continuous LLM extraction in the API process)
+# Free-tier Gemma pacing: calls are latency-bound (45-190s); the delay only
+# guards runs of small pages against the 30 RPM free-tier cap.
+EXTRACTION_WORKER_ENABLED=false
+EXTRACTION_DELAY_SECONDS=2
+
 # Production deployment
 # FRONTEND_URL=https://your-app.vercel.app    # Required in prod for CORS
 # WEB_CONCURRENCY=2                           # Gunicorn workers (default 2)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ make seed                 # Create tables + run migrations (idempotent)
 make reset-db             # Drop and recreate database from scratch
 
 # Scraping pipeline
-make scrape               # Full pipeline: fetch HTML → LLM extract → save → link match
+make scrape               # Fetch-only pipeline: download HTML + draft URL validation
 make fetch                # Stage 1: Download HTML from researcher URLs (hash-based change detection)
 make batch-submit         # Stage 2: Submit changed URLs to Gemini Batch API for extraction
 make batch-check          # Stage 3: Process completed batch results → save papers, snapshots, links
@@ -53,18 +53,21 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build  #
 
 ### Pipeline Details
 
-**`make scrape`** runs the full scheduler job (`scheduler.run_scrape_job()`). Fetch and extract run as **separate phases** — fetch always completes even if the LLM provider is down:
-1. **Fetch phase** (all URLs): Download HTML for all researcher URLs, skip unchanged (content hash). Collects list of changed URLs.
-2. **Extract phase** (changed URLs only): LLM extracts publications from changed pages, saves to `papers`. Includes link matching, title reconciliation, and paper snapshots.
-3. **Draft URL validation**: HEAD-request validation of `draft_url` fields
+**`make scrape`** runs the scheduler job (`scheduler.run_scrape_job()`), which is **fetch-only**:
+1. **Fetch phase** (all URLs): Download HTML for all researcher URLs, skip unchanged (content hash).
+2. **Draft URL validation**: HEAD-request validation of `draft_url` fields
+
+Extraction is owned by the extraction worker (below) — the scrape job only refreshes stored HTML and the `content_hash ≠ extracted_hash` queue.
 
 **Enrichment worker:** When `ENRICHMENT_WORKER_ENABLED=true`, a background thread in the API process continuously enriches unenriched papers via OpenAlex. Polls every 5 minutes, processes batches of 50, respects the daily budget. Backs off to 10-minute sleep after 5 consecutive failures. In local dev (worker disabled), run `make enrich` manually after scraping.
 
-**Extraction circuit breaker:** If 10 consecutive URLs return empty extraction results (e.g. LLM quota exhausted), the extraction phase stops early. Fetched HTML is preserved — extraction will resume on the next run for URLs where `content_hash ≠ extracted_hash`. The `scrape_log.extraction_errors` column tracks how many URLs failed extraction per run.
+**Extraction worker:** When `EXTRACTION_WORKER_ENABLED=true`, a background thread in the API process continuously extracts publications from changed pages (`content_hash ≠ extracted_hash`) using synchronous free-tier Gemma calls. Calls are latency-bound (45–190s each, ~35 output tokens/s); `EXTRACTION_DELAY_SECONDS` (default 2) paces the fast tail under the 30 RPM free-tier cap. Polls every 5 minutes when idle, backs off 10 minutes after 10 consecutive failures (quota exhaustion), and skips a URL for the process lifetime after 3 failed attempts (poison-pill guard). In local dev (worker disabled), run `make extract` manually after fetching.
+
+**Extraction circuit breaker (CLI):** The `make extract` CLI stops after 10 consecutive failed extractions (e.g. LLM quota exhausted). Fetched HTML is preserved — extraction resumes on the next run for URLs where `content_hash ≠ extracted_hash`. The continuous worker uses backoff + per-URL retry limits instead of stopping.
 
 **Stale scrape_log cleanup:** On scheduler start, any `scrape_log` entries stuck in `'running'` for >24 hours are automatically marked as `'failed'`.
 
-**`make fetch`** runs stage 1 only (download HTML). Extraction is handled exclusively by `make scrape` (scheduler), which uses diff-based extraction — the only path that correctly creates feed events.
+**`make fetch`** runs stage 1 only (download HTML). Extraction is handled by the extraction worker (or `make extract` manually) — both use the shared `extraction.extract_one_url()`, which protects feed event integrity via `_title_in_previous_snapshot()` and the `_url_has_baseline()` check.
 
 **Granular batch pipeline** (run stages independently):
 1. `make fetch` — Download HTML, detect changes via content hash. Safe to run anytime.
@@ -94,6 +97,7 @@ Researcher URLs (DB) → HTMLFetcher (fetch + hash-based change detection)
 | `main.py` | CLI entry points for scraping pipeline stages |
 | `html_fetcher.py` | Web scraper — per-domain rate limiting, robots.txt compliance, content hashing for change detection |
 | `publication.py` | LLM extraction (Google AI Studio/Gemini) — Pydantic structured outputs, title dedup via SHA-256 hash |
+| `extraction.py` | Per-URL extraction logic shared by worker and CLI — reads stored HTML, runs LLM, persists papers/links/snapshots, marks extracted |
 | `llm_client.py` | Google AI Studio LLM client — OpenAI-compatible SDK, guided JSON via `response_format`, retry with reprompt |
 | `link_extractor.py` | Trusted-domain link extraction from HTML, DOI-based and anchor text matching to papers |
 | `doi_resolver.py` | DOI resolution from publisher URLs — regex extraction + Crossref PII-to-DOI lookup |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ Extraction is owned by the extraction worker (below) — the scrape job only ref
 
 **Extraction circuit breaker (CLI):** The `make extract` CLI stops after 10 consecutive failed extractions (e.g. LLM quota exhausted). Fetched HTML is preserved — extraction resumes on the next run for URLs where `content_hash ≠ extracted_hash`. The continuous worker uses backoff + per-URL retry limits instead of stopping.
 
+**Paper merge:** `merge_duplicate_papers()` dedupes papers post-run.
+
 **Stale scrape_log cleanup:** On scheduler start, any `scrape_log` entries stuck in `'running'` for >24 hours are automatically marked as `'failed'`.
 
 **`make fetch`** runs stage 1 only (download HTML). Extraction is handled by the extraction worker (or `make extract` manually) — both use the shared `extraction.extract_one_url()`, which protects feed event integrity via `_title_in_previous_snapshot()` and the `_url_has_baseline()` check.
@@ -160,7 +162,7 @@ cd /opt/econ-newsfeed && ./scripts/deploy.sh
 git pull origin main && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 ```
 
-**Env vars:** Production `.env` lives on the server at `/opt/econ-newsfeed/.env`. Key differences from dev: `DB_HOST=db`, `FRONTEND_URL=https://econ-newsfeed.vercel.app`, `WEB_CONCURRENCY=2`.
+**Env vars:** Production `.env` lives on the server at `/opt/econ-newsfeed/.env`. Key differences from dev: `DB_HOST=db`, `FRONTEND_URL=https://econ-newsfeed.vercel.app`, `WEB_CONCURRENCY=2`, `EXTRACTION_WORKER_ENABLED=true` (required in prod — the scrape job is fetch-only, so without the worker extraction stops).
 
 ## Configuration
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev kill seed reset-db scrape fetch batch-submit batch-check classify-jel enrich enrich-jel discover-domains backfill-normalize populate-fields backfill-affiliations audit-zero-pubs check
+.PHONY: setup dev kill seed reset-db scrape fetch extract batch-submit batch-check classify-jel enrich enrich-jel discover-domains backfill-normalize populate-fields backfill-affiliations audit-zero-pubs check
 
 setup:
 	poetry install
@@ -33,6 +33,9 @@ scrape:
 
 fetch:
 	poetry run python -c "from main import download_htmls; download_htmls()"
+
+extract:  ## Run LLM extraction for URLs with pending changes (no fetching)
+	poetry run python main.py extract
 
 batch-submit:
 	poetry run python main.py batch-submit

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -47,6 +47,7 @@ from database.researchers import (
     get_fields_for_researchers,
     get_deactivated_urls,
     get_at_risk_urls,
+    get_urls_needing_extraction,
     reactivate_url,
 )
 from database.papers import (
@@ -128,6 +129,7 @@ class Database:
     get_fields_for_researchers = staticmethod(get_fields_for_researchers)
     get_deactivated_urls = staticmethod(get_deactivated_urls)
     get_at_risk_urls = staticmethod(get_at_risk_urls)
+    get_urls_needing_extraction = staticmethod(get_urls_needing_extraction)
     reactivate_url = staticmethod(reactivate_url)
 
     # Papers

--- a/database/researchers.py
+++ b/database/researchers.py
@@ -403,6 +403,24 @@ def get_at_risk_urls() -> list[dict]:
     )
 
 
+def get_urls_needing_extraction() -> list[dict]:
+    """Active researcher URLs whose stored HTML changed since last extraction.
+
+    A URL needs extraction when its content_hash differs from extracted_hash
+    (changed since last LLM run, or never extracted). URLs with no stored
+    HTML are excluded (nothing to extract).
+    """
+    query = """
+        SELECT ru.id, ru.researcher_id, ru.url, ru.page_type
+        FROM researcher_urls ru
+        JOIN html_content hc ON hc.url_id = ru.id
+        WHERE ru.is_active = TRUE
+          AND (hc.extracted_hash IS NULL OR hc.extracted_hash != hc.content_hash)
+        ORDER BY ru.id
+    """
+    return fetch_all(query)
+
+
 def reactivate_url(url_id: int) -> None:
     """Re-activate a deactivated URL and reset all failure tracking."""
     execute_query(

--- a/database/researchers.py
+++ b/database/researchers.py
@@ -415,6 +415,7 @@ def get_urls_needing_extraction() -> list[dict]:
         FROM researcher_urls ru
         JOIN html_content hc ON hc.url_id = ru.id
         WHERE ru.is_active = TRUE
+          AND hc.content_hash IS NOT NULL
           AND (hc.extracted_hash IS NULL OR hc.extracted_hash != hc.content_hash)
         ORDER BY ru.id
     """

--- a/extraction.py
+++ b/extraction.py
@@ -35,7 +35,13 @@ class ExtractionOutcome:
 
 
 def extract_one_url(url_row: dict, scrape_log_id: int | None = None) -> ExtractionOutcome:
-    """Extract publications for one researcher URL from stored HTML."""
+    """Extract publications for one researcher URL from stored HTML.
+
+    is_seed deliberately uses extracted_at IS NULL (first *extraction*), not
+    fetch-time state — decoupled from fetching, that is the only reliable
+    seed signal and it stays correct when a URL is fetched repeatedly before
+    its first extraction.
+    """
     url_id = url_row['id']
     url = url_row['url']
     researcher_id = url_row['researcher_id']

--- a/extraction.py
+++ b/extraction.py
@@ -41,6 +41,11 @@ def extract_one_url(url_row: dict, scrape_log_id: int | None = None) -> Extracti
     fetch-time state — decoupled from fetching, that is the only reliable
     seed signal and it stays correct when a URL is fetched repeatedly before
     its first extraction.
+
+    A crash between save_publications and mark_extracted re-extracts the URL
+    on the next pass; saves dedup via title_hash, but a duplicate paper
+    snapshot / status_change event is possible in that window — accepted
+    tradeoff of the non-transactional persist-then-mark sequence.
     """
     url_id = url_row['id']
     url = url_row['url']

--- a/extraction.py
+++ b/extraction.py
@@ -1,0 +1,94 @@
+"""Per-URL publication extraction, shared by the background worker and CLI.
+
+Decoupled from fetching: reads stored HTML, runs LLM extraction on the full
+text, persists papers/links/snapshots, and marks the URL extracted with the
+content hash read *before* the LLM call — so a fetch that updates the page
+mid-extraction leaves the URL in the needs-extraction queue.
+"""
+import logging
+from dataclasses import dataclass
+
+from database import Database
+from html_fetcher import HTMLFetcher
+from link_extractor import match_and_save_paper_links
+from publication import Publication, append_snapshots_for_pubs, reconcile_title_renames
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExtractionOutcome:
+    """Result of extracting one URL.
+
+    status values:
+      'extracted'  — publications found and saved; URL marked extracted
+      'empty'      — LLM succeeded, page has no publications; URL marked extracted
+      'failed'     — LLM call failed; URL NOT marked, will be retried
+      'no_content' — no stored HTML/text; URL NOT marked
+    """
+    status: str
+    pubs_count: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return self.status in ("extracted", "empty")
+
+
+def extract_one_url(url_row: dict, scrape_log_id: int | None = None) -> ExtractionOutcome:
+    """Extract publications for one researcher URL from stored HTML."""
+    url_id = url_row['id']
+    url = url_row['url']
+    researcher_id = url_row['researcher_id']
+    page_type = url_row['page_type']
+
+    payload = HTMLFetcher.get_extraction_payload(url_id)
+    if not payload:
+        return ExtractionOutcome("no_content")
+
+    text = payload['content']
+    if not text and payload['raw_html']:
+        text = HTMLFetcher.extract_text_content(payload['raw_html'])
+    if not text:
+        return ExtractionOutcome("no_content")
+    content_hash = payload['content_hash']
+
+    is_seed = HTMLFetcher.is_first_extraction(url_id)
+    pubs = Publication.try_extract_publications(text, url, scrape_log_id=scrape_log_id)
+    if pubs is None:
+        return ExtractionOutcome("failed")
+
+    if pubs:
+        Publication.save_publications(url, pubs, is_seed=is_seed)
+        reconcile_title_renames(url, pubs)
+        match_and_save_paper_links(url_id, pubs)
+        append_snapshots_for_pubs(pubs, url)
+
+    if page_type == "HOME":
+        _update_home_description(researcher_id, text, url, scrape_log_id)
+
+    HTMLFetcher.mark_extracted(url_id, content_hash)
+    return ExtractionOutcome("extracted" if pubs else "empty", pubs_count=len(pubs))
+
+
+def _update_home_description(researcher_id: int, text: str, url: str,
+                             scrape_log_id: int | None = None) -> None:
+    """Best-effort researcher description refresh from a HOME page.
+
+    Failures are logged, never propagated — a description glitch must not
+    block publication extraction.
+    """
+    try:
+        description = HTMLFetcher.extract_description(text, url, scrape_log_id=scrape_log_id)
+        if not description:
+            return
+        r_row = Database.fetch_one(
+            "SELECT position, affiliation FROM researchers WHERE id = %s",
+            (researcher_id,),
+        )
+        position = r_row['position'] if r_row else None
+        affiliation = r_row['affiliation'] if r_row else None
+        Database.append_researcher_snapshot(
+            researcher_id, position, affiliation, description, source_url=url,
+        )
+    except Exception as e:
+        logger.error("Description update failed for %s: %s: %s", url, type(e).__name__, e)

--- a/html_fetcher.py
+++ b/html_fetcher.py
@@ -1,4 +1,3 @@
-import difflib
 import ipaddress
 import os
 import re
@@ -756,23 +755,4 @@ class HTMLFetcher:
                 (now, extracted_hash, url_id),
             )
 
-    @staticmethod
-    def get_previous_text(url_id: int) -> str | None:
-        """Retrieve the previous text content for a given URL ID (before current upsert).
-        With upsert, there's only one row per url_id, so this returns the current stored
-        content (which represents the *previous* version before fetch_and_save_if_changed
-        overwrites it).
-        """
-        return HTMLFetcher.get_latest_text(url_id)
 
-    @staticmethod
-    def compute_diff(old_text: str, new_text: str) -> str:
-        """Compute a unified diff between old and new text content.
-        Returns only added/changed lines to reduce LLM token usage.
-        """
-        old_lines = old_text.splitlines(keepends=True)
-        new_lines = new_text.splitlines(keepends=True)
-        diff = difflib.unified_diff(old_lines, new_lines, n=1)
-        # Extract only added lines (starting with '+' but not '+++')
-        added_lines = [line[1:] for line in diff if line.startswith('+') and not line.startswith('+++')]
-        return ''.join(added_lines) if added_lines else new_text

--- a/html_fetcher.py
+++ b/html_fetcher.py
@@ -694,6 +694,18 @@ class HTMLFetcher:
         return result['raw_html'] if result else None
 
     @staticmethod
+    def get_extraction_payload(url_id: int) -> dict | None:
+        """Read content, raw_html, and content_hash in one query for extraction.
+
+        Reading the hash together with the text guarantees mark_extracted()
+        can record exactly what was extracted.
+        """
+        return Database.fetch_one(
+            "SELECT content, raw_html, content_hash FROM html_content WHERE url_id = %s",
+            (url_id,),
+        )
+
+    @staticmethod
     def needs_extraction(url_id: int) -> bool:
         """
         Return True if LLM extraction is needed for this URL.
@@ -723,17 +735,26 @@ class HTMLFetcher:
         return result is not None and result['extracted_at'] is None
 
     @staticmethod
-    def mark_extracted(url_id: int) -> None:
+    def mark_extracted(url_id: int, extracted_hash: str | None = None) -> None:
+        """Record that extraction has run.
+
+        Pass the content_hash that was read at extraction *start* so a fetch
+        landing mid-extraction is not silently marked as extracted (the URL
+        stays in the needs-extraction queue). When extracted_hash is None,
+        falls back to copying the current content_hash (legacy callers where
+        fetch and extraction cannot overlap).
         """
-        Record that extraction has been run on the current content by setting
-        extracted_hash = content_hash and extracted_at = now.
-        """
-        query = """
-            UPDATE html_content
-            SET extracted_at = %s, extracted_hash = content_hash
-            WHERE url_id = %s
-        """
-        Database.execute_query(query, (datetime.now(timezone.utc), url_id))
+        now = datetime.now(timezone.utc)
+        if extracted_hash is None:
+            Database.execute_query(
+                "UPDATE html_content SET extracted_at = %s, extracted_hash = content_hash WHERE url_id = %s",
+                (now, url_id),
+            )
+        else:
+            Database.execute_query(
+                "UPDATE html_content SET extracted_at = %s, extracted_hash = %s WHERE url_id = %s",
+                (now, extracted_hash, url_id),
+            )
 
     @staticmethod
     def get_previous_text(url_id: int) -> str | None:

--- a/main.py
+++ b/main.py
@@ -321,10 +321,9 @@ def batch_check() -> None:
 def extract_only(limit: int | None = None) -> None:
     """Run LLM extraction for URLs with pending content changes (skips fetching)."""
     from scheduler import create_scrape_log, update_scrape_log, _update_progress
+    from extraction import extract_one_url
 
-    researcher_urls = Researcher.get_all_researcher_urls()
-    pending = [row for row in researcher_urls if HTMLFetcher.needs_extraction(row['id'])]
-
+    pending = Database.get_urls_needing_extraction()
     if not pending:
         logging.info("No URLs need extraction")
         return
@@ -342,48 +341,31 @@ def extract_only(limit: int | None = None) -> None:
 
     try:
         for idx, row in enumerate(pending):
-            url_id = row['id']
-            url = row['url']
-            researcher_id = row['researcher_id']
-
             try:
-                new_text = HTMLFetcher.get_latest_text(url_id)
-                if not new_text:
-                    raw_html = HTMLFetcher.get_raw_html(url_id)
-                    if raw_html:
-                        new_text = HTMLFetcher.extract_text_content(raw_html)
-                if not new_text:
-                    continue
-
-                is_seed = HTMLFetcher.is_first_extraction(url_id)
-
-                pubs = Publication.extract_publications(new_text, url, scrape_log_id=log_id)
-                logging.info("[%d/%d] extract %s — %d pubs", idx + 1, len(pending), url, len(pubs))
-
-                if pubs:
-                    consecutive_failures = 0
-                    Publication.save_publications(url, pubs, is_seed=is_seed)
-                    reconcile_title_renames(url, pubs)
-                    pubs_extracted += len(pubs)
-                    match_and_save_paper_links(url_id, pubs)
-                    append_snapshots_for_pubs(pubs, url)
-                else:
-                    consecutive_failures += 1
-                    extraction_errors += 1
-                    if consecutive_failures >= 10:
-                        logging.warning("Circuit breaker: 10 consecutive empty extractions")
-                        break
-
-                HTMLFetcher.mark_extracted(url_id)
-                _update_progress(log_id, pubs_extracted=pubs_extracted, extraction_errors=extraction_errors)
-
+                outcome = extract_one_url(row, scrape_log_id=log_id)
             except Exception as e:
-                logging.error("Error extracting %s: %s", url, e)
+                logging.error("Error extracting %s: %s", row['url'], e)
                 extraction_errors += 1
                 consecutive_failures += 1
                 if consecutive_failures >= 10:
                     logging.warning("Circuit breaker: 10 consecutive failures")
                     break
+                continue
+
+            logging.info("[%d/%d] extract %s — %s (%d pubs)",
+                         idx + 1, len(pending), row['url'], outcome.status, outcome.pubs_count)
+
+            if outcome.ok:
+                consecutive_failures = 0
+                pubs_extracted += outcome.pubs_count
+            else:
+                consecutive_failures += 1
+                extraction_errors += 1
+                if consecutive_failures >= 10:
+                    logging.warning("Circuit breaker: 10 consecutive extraction failures")
+                    break
+
+            _update_progress(log_id, pubs_extracted=pubs_extracted, extraction_errors=extraction_errors)
 
         update_scrape_log(log_id, "completed", urls_checked=0, urls_changed=len(pending),
                           pubs_extracted=pubs_extracted, extraction_errors=extraction_errors)

--- a/publication.py
+++ b/publication.py
@@ -255,8 +255,13 @@ Content:
 {text_content[:CONTENT_MAX_CHARS]}"""
 
     @staticmethod
-    def extract_publications(text_content: str, url: str, scrape_log_id: int | None = None) -> list[dict]:
-        """Use the configured LLM to extract publication details from text content."""
+    def try_extract_publications(text_content: str, url: str, scrape_log_id: int | None = None) -> list[dict] | None:
+        """Extract publications via the LLM.
+
+        Returns None when the LLM call failed (API error, schema validation
+        failure after retries) — callers should retry the URL later. Returns
+        [] when the call succeeded but the page genuinely has no publications.
+        """
         prompt = Publication.build_extraction_prompt(text_content, url)
         model = get_model()
         logging.info(f"Extracting publications from {url} using LLM ({model})")
@@ -271,7 +276,7 @@ Content:
 
         if result.parsed is None:
             logging.warning(f"Publication extraction returned no parsed result for {url}")
-            return []
+            return None
 
         validated = []
         for pub in result.parsed.publications:
@@ -281,6 +286,12 @@ Content:
             else:
                 logging.info(f"Validation dropped: {d.get('title', '<no title>')}")
         return validated
+
+    @staticmethod
+    def extract_publications(text_content: str, url: str, scrape_log_id: int | None = None) -> list[dict]:
+        """Legacy wrapper: failure collapses to [] (kept for scheduler/batch callers)."""
+        pubs = Publication.try_extract_publications(text_content, url, scrape_log_id=scrape_log_id)
+        return pubs if pubs is not None else []
 
 
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -497,11 +497,15 @@ def start_scheduler() -> None:
     if ENRICHMENT_WORKER_ENABLED:
         start_enrichment_worker()
 
+    if EXTRACTION_WORKER_ENABLED:
+        start_extraction_worker()
+
 
 def shutdown_scheduler() -> None:
     """Shut down the scheduler gracefully, waiting for any running job to complete."""
     global _scheduler, _scheduler_lock_conn
     stop_enrichment_worker()
+    stop_extraction_worker()
     if _scheduler is not None:
         _scheduler.shutdown(wait=True)
         _scheduler = None

--- a/scheduler.py
+++ b/scheduler.py
@@ -76,6 +76,16 @@ _ENRICHMENT_BACKOFF_SECONDS = 600  # 10 minutes
 _enrichment_thread = None
 _enrichment_stop_event = threading.Event()
 
+EXTRACTION_WORKER_ENABLED = os.environ.get('EXTRACTION_WORKER_ENABLED', 'false').lower() == 'true'
+_EXTRACTION_DELAY_SECONDS = float(os.environ.get('EXTRACTION_DELAY_SECONDS', '2'))
+_EXTRACTION_IDLE_SECONDS = 300       # queue empty → re-poll every 5 min
+_EXTRACTION_BACKOFF_THRESHOLD = 10   # consecutive failures before backing off
+_EXTRACTION_BACKOFF_SECONDS = 600    # 10 min (rides out free-tier quota exhaustion)
+_EXTRACTION_MAX_URL_FAILURES = 3     # poison-pill guard: skip URL until restart
+
+_extraction_thread = None
+_extraction_stop_event = threading.Event()
+
 
 def create_scrape_log() -> int:
     """Create a new scrape_log entry and return its ID."""
@@ -338,6 +348,101 @@ def stop_enrichment_worker() -> None:
     _enrichment_thread.join(timeout=30)
     _enrichment_thread = None
     logger.info("Enrichment worker thread stopped")
+
+
+def _extraction_worker_loop() -> None:
+    """Continuously extract publications from changed pages until stopped.
+
+    Free-tier Gemma pacing (measured 2026-06-09, see spec): calls take
+    45-190s on real pages so the worker is latency-bound; the fixed delay
+    only guards runs of tiny pages against the 30 RPM cap.
+    """
+    from extraction import extract_one_url
+
+    logger.info("Extraction worker started")
+    url_failures: dict[int, int] = {}
+    consecutive_failures = 0
+    processed = 0
+    pubs_total = 0
+
+    while not _extraction_stop_event.is_set():
+        try:
+            queue = Database.get_urls_needing_extraction()
+        except Exception as e:
+            logger.error("Extraction worker queue query failed: %s: %s", type(e).__name__, e)
+            _extraction_stop_event.wait(_EXTRACTION_IDLE_SECONDS)
+            continue
+
+        pending = [r for r in queue if url_failures.get(r['id'], 0) < _EXTRACTION_MAX_URL_FAILURES]
+        if not pending:
+            _extraction_stop_event.wait(_EXTRACTION_IDLE_SECONDS)
+            continue
+
+        logger.info("Extraction worker: %d URLs pending (%d skipped as poison pills)",
+                    len(pending), len(queue) - len(pending))
+
+        for row in pending:
+            if _extraction_stop_event.is_set():
+                break
+            url_id = row['id']
+            try:
+                outcome = extract_one_url(row)
+            except Exception as e:
+                logger.error("Extraction worker error on %s (id=%s): %s: %s",
+                             row['url'], url_id, type(e).__name__, e)
+                outcome = None
+
+            processed += 1
+            if outcome is not None and outcome.ok:
+                consecutive_failures = 0
+                url_failures.pop(url_id, None)
+                pubs_total += outcome.pubs_count
+            else:
+                consecutive_failures += 1
+                url_failures[url_id] = url_failures.get(url_id, 0) + 1
+                if url_failures[url_id] >= _EXTRACTION_MAX_URL_FAILURES:
+                    logger.warning("Extraction worker: skipping url_id=%s (%s) after %d failures "
+                                   "until next restart", url_id, row['url'], url_failures[url_id])
+
+            if processed % 25 == 0:
+                logger.info("Extraction worker progress: %d processed, %d pubs total", processed, pubs_total)
+
+            if consecutive_failures >= _EXTRACTION_BACKOFF_THRESHOLD:
+                logger.warning("Extraction worker backing off %ds after %d consecutive failures "
+                               "(likely quota exhausted)", _EXTRACTION_BACKOFF_SECONDS, consecutive_failures)
+                _extraction_stop_event.wait(_EXTRACTION_BACKOFF_SECONDS)
+            else:
+                _extraction_stop_event.wait(_EXTRACTION_DELAY_SECONDS)
+
+    logger.info("Extraction worker stopped (%d processed, %d pubs)", processed, pubs_total)
+
+
+def start_extraction_worker() -> None:
+    """Start the extraction background worker thread."""
+    global _extraction_thread
+    if _extraction_thread is not None and _extraction_thread.is_alive():
+        logger.warning("Extraction worker already running")
+        return
+
+    _extraction_stop_event.clear()
+    _extraction_thread = threading.Thread(
+        target=_extraction_worker_loop,
+        name="extraction-worker",
+        daemon=True,
+    )
+    _extraction_thread.start()
+    logger.info("Extraction worker thread started")
+
+
+def stop_extraction_worker() -> None:
+    """Stop the extraction worker gracefully."""
+    global _extraction_thread
+    if _extraction_thread is None:
+        return
+    _extraction_stop_event.set()
+    _extraction_thread.join(timeout=30)
+    _extraction_thread = None
+    logger.info("Extraction worker thread stopped")
 
 
 def start_scheduler() -> None:

--- a/scheduler.py
+++ b/scheduler.py
@@ -13,8 +13,6 @@ from database import Database
 from db_config import db_config
 from researcher import Researcher
 from html_fetcher import HTMLFetcher
-from publication import Publication, reconcile_title_renames, append_snapshots_for_pubs
-from link_extractor import match_and_save_paper_links
 logger = logging.getLogger(__name__)
 
 _LOCK_NAME = 'econ_newsfeed_scrape'
@@ -167,8 +165,6 @@ def _validate_draft_urls() -> None:
             logger.error(f"Error validating draft URL for paper {paper_id}: {e}")
 
 
-_EXTRACTION_CIRCUIT_BREAKER_THRESHOLD = 10
-
 _TRANSIENT_MYSQL_ERRORS = (
     mysql.connector.errors.OperationalError,
     mysql.connector.errors.InterfaceError,
@@ -199,10 +195,10 @@ def _with_db_retry(fn, *args, max_retries: int = 3, **kwargs):
 
 
 def run_scrape_job() -> None:
-    """Orchestrates a full scraping cycle: fetch all HTML first, then extract.
+    """Fetch HTML for all researcher URLs (change detection via content hash).
 
-    Fetch always completes. Extraction circuit-breaks after
-    _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD consecutive failures (e.g. quota exhausted).
+    Extraction is owned by the continuous extraction worker — this job only
+    downloads pages and validates draft URLs.
     """
     global _lock_conn
     lock_conn = _acquire_db_lock()
@@ -219,24 +215,15 @@ def run_scrape_job() -> None:
         urls = Researcher.get_all_researcher_urls()
         urls_checked = 0
         urls_changed = 0
-        pubs_extracted = 0
-        extraction_errors = 0
 
-        # ── PHASE 1: Fetch all HTML ──────────────────────────────────
         scrape_start = time.time()
-        changed_urls = []
-
         for url_row in urls:
             url_id = url_row['id']
             researcher_id = url_row['researcher_id']
             url = url_row['url']
-            page_type = url_row['page_type']
             urls_checked += 1
 
             try:
-                old_text = _with_db_retry(HTMLFetcher.get_previous_text, url_id)
-                is_first_scrape = old_text is None
-
                 t0 = time.time()
                 changed = _with_db_retry(HTMLFetcher.fetch_and_save_if_changed, url_id, url, researcher_id)
                 fetch_ms = (time.time() - t0) * 1000
@@ -244,11 +231,6 @@ def run_scrape_job() -> None:
 
                 if changed:
                     urls_changed += 1
-                    changed_urls.append({
-                        **url_row,
-                        'old_text': old_text,
-                        'is_first_scrape': is_first_scrape,
-                    })
 
                 if urls_checked % 10 == 0:
                     _with_db_retry(_update_progress, log_id, urls_checked=urls_checked, urls_changed=urls_changed)
@@ -264,131 +246,14 @@ def run_scrape_job() -> None:
         fetch_phase_s = time.time() - scrape_start
         logger.info(f"Fetch phase done: {fetch_phase_s:.1f}s — {urls_checked} checked, {urls_changed} changed")
 
-        # ── PHASE 2: Extract publications from changed URLs ──────────
-        extract_start = time.time()
-        consecutive_failures = 0
-        circuit_broken = False
-
-        for idx, entry in enumerate(changed_urls):
-            url_id = entry['id']
-            researcher_id = entry['researcher_id']
-            url = entry['url']
-            page_type = entry['page_type']
-            old_text = entry.pop('old_text')
-            is_first_scrape = entry.pop('is_first_scrape')
-
-            if circuit_broken:
-                break
-
-            try:
-                new_text = _with_db_retry(HTMLFetcher.get_latest_text, url_id)
-                extraction_text = HTMLFetcher.compute_diff(old_text, new_text) if old_text else new_text
-
-                if extraction_text:
-                    t0 = time.time()
-                    pubs = Publication.extract_publications(extraction_text, url, scrape_log_id=log_id)
-                    extract_ms = (time.time() - t0) * 1000
-                    logger.info(f"  LLM extract {url} — {extract_ms:.0f}ms, {len(pubs)} pubs")
-
-                    if pubs:
-                        consecutive_failures = 0
-
-                        t0 = time.time()
-                        _with_db_retry(Publication.save_publications, url, pubs, is_seed=is_first_scrape)
-                        save_ms = (time.time() - t0) * 1000
-                        logger.info(f"  save_publications — {save_ms:.0f}ms")
-
-                        t0_recon = time.time()
-                        _with_db_retry(reconcile_title_renames, url, pubs)
-                        recon_ms = (time.time() - t0_recon) * 1000
-                        logger.info(f"  title reconciliation — {recon_ms:.0f}ms")
-
-                        pubs_extracted += len(pubs)
-
-                        t0 = time.time()
-                        _with_db_retry(match_and_save_paper_links, url_id, pubs)
-                        links_ms = (time.time() - t0) * 1000
-                        logger.info(f"  paper links — {links_ms:.0f}ms")
-
-                        t0 = time.time()
-                        _with_db_retry(append_snapshots_for_pubs, pubs, url)
-                        snapshot_ms = (time.time() - t0) * 1000
-                        logger.info(f"  paper snapshots — {snapshot_ms:.0f}ms")
-                    else:
-                        consecutive_failures += 1
-                        extraction_errors += 1
-                        if consecutive_failures >= _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD:
-                            remaining = len(changed_urls) - idx - 1
-                            logger.warning(
-                                "Circuit breaker: %d consecutive extraction failures — "
-                                "stopping extraction (likely LLM quota exhausted). "
-                                "Remaining %d changed URLs will be extracted next run.",
-                                consecutive_failures, remaining,
-                            )
-                            circuit_broken = True
-
-                _with_db_retry(_update_progress, log_id, pubs_extracted=pubs_extracted, extraction_errors=extraction_errors)
-
-                if page_type == "HOME" and not circuit_broken and new_text:
-                    t0 = time.time()
-                    description = HTMLFetcher.extract_description(new_text, url, scrape_log_id=log_id)
-                    desc_ms = (time.time() - t0) * 1000
-                    logger.info(f"  description extract — {desc_ms:.0f}ms (found={description is not None})")
-                    if description:
-                        r_row = _with_db_retry(
-                            Database.fetch_one,
-                            "SELECT position, affiliation FROM researchers WHERE id = %s",
-                            (researcher_id,),
-                        )
-                        position = r_row['position'] if r_row else None
-                        affiliation = r_row['affiliation'] if r_row else None
-                        _with_db_retry(
-                            Database.append_researcher_snapshot,
-                            researcher_id, position, affiliation, description, source_url=url,
-                        )
-
-            except _TRANSIENT_MYSQL_ERRORS as e:
-                logger.error("MySQL connection error extracting URL %s (id=%s) after retries: %s", url, url_id, e)
-                extraction_errors += 1
-                consecutive_failures += 1
-                if consecutive_failures >= _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD:
-                    remaining = len(changed_urls) - idx - 1
-                    logger.warning(
-                        "Circuit breaker: %d consecutive extraction failures — "
-                        "stopping extraction. Remaining %d changed URLs will be extracted next run.",
-                        consecutive_failures, remaining,
-                    )
-                    circuit_broken = True
-                continue
-            except Exception as e:
-                logger.error("Error extracting URL %s (id=%s): %s", url, url_id, e)
-                extraction_errors += 1
-                consecutive_failures += 1
-                if consecutive_failures >= _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD:
-                    remaining = len(changed_urls) - idx - 1
-                    logger.warning(
-                        "Circuit breaker: %d consecutive extraction failures — "
-                        "stopping extraction. Remaining %d changed URLs will be extracted next run.",
-                        consecutive_failures, remaining,
-                    )
-                    circuit_broken = True
-                continue
-
-        extract_phase_s = time.time() - extract_start
-        logger.info(f"Extract phase done: {extract_phase_s:.1f}s — {pubs_extracted} pubs, {extraction_errors} errors")
-
         t0 = time.time()
         _validate_draft_urls()
         validate_s = time.time() - t0
         logger.info(f"Draft URL validation: {validate_s:.1f}s")
 
-        error_msg = None
-        if circuit_broken:
-            error_msg = f"Extraction circuit-breaker tripped after {_EXTRACTION_CIRCUIT_BREAKER_THRESHOLD} consecutive failures"
-
         total_s = time.time() - scrape_start
-        update_scrape_log(log_id, "completed", urls_checked, urls_changed, pubs_extracted, extraction_errors, error_msg)
-        logger.info(f"Scrape completed: {urls_checked} checked, {urls_changed} changed, {pubs_extracted} extracted, {extraction_errors} errors — {total_s:.1f}s total")
+        update_scrape_log(log_id, "completed", urls_checked, urls_changed)
+        logger.info(f"Scrape completed: {urls_checked} checked, {urls_changed} changed — {total_s:.1f}s total")
 
     except Exception as e:
         logger.error("Scrape job failed: %s: %s", type(e).__name__, e)

--- a/tests/test_db_researchers.py
+++ b/tests/test_db_researchers.py
@@ -401,3 +401,24 @@ class TestSearchResearchers:
         (_, _), mock_fetch = self._call()
         sql, _ = mock_fetch.call_args[0]
         assert "WHERE" in sql
+
+
+# ---------------------------------------------------------------------------
+# get_urls_needing_extraction
+# ---------------------------------------------------------------------------
+
+class TestGetUrlsNeedingExtraction:
+    def test_queries_active_urls_with_hash_mismatch(self):
+        from database.researchers import get_urls_needing_extraction
+        rows = [{"id": 1, "researcher_id": 10, "url": "https://a.com", "page_type": "PUBLICATIONS"}]
+        with patch("database.researchers.fetch_all", return_value=rows) as mock_fetch:
+            result = get_urls_needing_extraction()
+        assert result == rows
+        query = mock_fetch.call_args[0][0]
+        assert "is_active = TRUE" in query
+        assert "extracted_hash IS NULL" in query
+        assert "extracted_hash != hc.content_hash" in query
+
+    def test_facade_exposes_it(self):
+        from database import Database
+        assert hasattr(Database, "get_urls_needing_extraction")

--- a/tests/test_db_researchers.py
+++ b/tests/test_db_researchers.py
@@ -416,6 +416,7 @@ class TestGetUrlsNeedingExtraction:
         assert result == rows
         query = mock_fetch.call_args[0][0]
         assert "is_active = TRUE" in query
+        assert "content_hash IS NOT NULL" in query
         assert "extracted_hash IS NULL" in query
         assert "extracted_hash != hc.content_hash" in query
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,170 @@
+"""Tests for extraction.extract_one_url — shared per-URL extraction logic."""
+import os
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_USER", "test")
+os.environ.setdefault("DB_PASSWORD", "test")
+os.environ.setdefault("DB_NAME", "test_econ_newsfeed")
+os.environ.setdefault("GOOGLE_API_KEY", "test-google-key")
+os.environ.setdefault("SCRAPE_API_KEY", "test-key")
+os.environ.setdefault("CONTENT_MAX_CHARS", "20000")
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _row(url_id=1, researcher_id=10, url="https://example.com/pubs", page_type="PUBLICATIONS"):
+    return {"id": url_id, "researcher_id": researcher_id, "url": url, "page_type": page_type}
+
+
+def _patches(payload=None, pubs=None, is_seed=False):
+    """Common patch set. pubs=None simulates LLM failure."""
+    if payload is None:
+        payload = {"content": "page text", "raw_html": "<html>", "content_hash": "h1"}
+    return {
+        "payload": patch("extraction.HTMLFetcher.get_extraction_payload", return_value=payload),
+        "is_first": patch("extraction.HTMLFetcher.is_first_extraction", return_value=is_seed),
+        "mark": patch("extraction.HTMLFetcher.mark_extracted"),
+        "extract_text": patch("extraction.HTMLFetcher.extract_text_content", return_value="from raw html"),
+        "extract_desc": patch("extraction.HTMLFetcher.extract_description", return_value=None),
+        "try_extract": patch("extraction.Publication.try_extract_publications", return_value=pubs),
+        "save": patch("extraction.Publication.save_publications"),
+        "reconcile": patch("extraction.reconcile_title_renames"),
+        "links": patch("extraction.match_and_save_paper_links"),
+        "snapshots": patch("extraction.append_snapshots_for_pubs"),
+        "fetch_one": patch("extraction.Database.fetch_one", return_value=None),
+        "researcher_snap": patch("extraction.Database.append_researcher_snapshot"),
+    }
+
+
+class TestExtractOneUrl:
+    def test_happy_path_saves_and_marks_with_start_hash(self):
+        from extraction import extract_one_url
+        pubs = [{"title": "Paper A"}, {"title": "Paper B"}]
+        patches = _patches(pubs=pubs)
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            outcome = extract_one_url(_row())
+        finally:
+            for p in patches.values():
+                p.stop()
+        assert outcome.status == "extracted"
+        assert outcome.pubs_count == 2
+        assert outcome.ok
+        mocks["save"].assert_called_once_with("https://example.com/pubs", pubs, is_seed=False)
+        mocks["reconcile"].assert_called_once()
+        mocks["links"].assert_called_once_with(1, pubs)
+        mocks["snapshots"].assert_called_once_with(pubs, "https://example.com/pubs")
+        mocks["mark"].assert_called_once_with(1, "h1")
+
+    def test_llm_failure_returns_failed_and_does_not_mark(self):
+        from extraction import extract_one_url
+        patches = _patches(pubs=None)  # try_extract returns None = LLM failure
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            outcome = extract_one_url(_row())
+        finally:
+            for p in patches.values():
+                p.stop()
+        assert outcome.status == "failed"
+        assert not outcome.ok
+        mocks["mark"].assert_not_called()
+        mocks["save"].assert_not_called()
+
+    def test_genuinely_empty_page_marks_extracted(self):
+        from extraction import extract_one_url
+        patches = _patches(pubs=[])
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            outcome = extract_one_url(_row())
+        finally:
+            for p in patches.values():
+                p.stop()
+        assert outcome.status == "empty"
+        assert outcome.ok
+        mocks["mark"].assert_called_once_with(1, "h1")
+        mocks["save"].assert_not_called()
+
+    def test_no_stored_html_returns_no_content(self):
+        from extraction import extract_one_url
+        patches = _patches(pubs=[])
+        patches["payload"] = patch("extraction.HTMLFetcher.get_extraction_payload", return_value=None)
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            outcome = extract_one_url(_row())
+        finally:
+            for p in patches.values():
+                p.stop()
+        assert outcome.status == "no_content"
+        assert not outcome.ok
+        mocks["mark"].assert_not_called()
+
+    def test_null_content_falls_back_to_raw_html(self):
+        from extraction import extract_one_url
+        payload = {"content": None, "raw_html": "<html>x</html>", "content_hash": "h2"}
+        patches = _patches(payload=payload, pubs=[])
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            outcome = extract_one_url(_row())
+        finally:
+            for p in patches.values():
+                p.stop()
+        assert outcome.ok
+        mocks["extract_text"].assert_called_once_with("<html>x</html>")
+        mocks["try_extract"].assert_called_once()
+        assert mocks["try_extract"].call_args[0][0] == "from raw html"
+
+    def test_seed_flag_passed_through(self):
+        from extraction import extract_one_url
+        patches = _patches(pubs=[{"title": "P"}], is_seed=True)
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            extract_one_url(_row())
+        finally:
+            for p in patches.values():
+                p.stop()
+        assert mocks["save"].call_args[1]["is_seed"] is True
+
+    def test_home_page_updates_description(self):
+        from extraction import extract_one_url
+        patches = _patches(pubs=[])
+        patches["extract_desc"] = patch(
+            "extraction.HTMLFetcher.extract_description", return_value="An economist.")
+        patches["fetch_one"] = patch(
+            "extraction.Database.fetch_one",
+            return_value={"position": "Prof", "affiliation": "MIT"})
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            outcome = extract_one_url(_row(page_type="HOME"))
+        finally:
+            for p in patches.values():
+                p.stop()
+        assert outcome.ok
+        mocks["researcher_snap"].assert_called_once_with(
+            10, "Prof", "MIT", "An economist.", source_url="https://example.com/pubs")
+
+    def test_description_failure_does_not_fail_extraction(self):
+        from extraction import extract_one_url
+        patches = _patches(pubs=[])
+        patches["extract_desc"] = patch(
+            "extraction.HTMLFetcher.extract_description", side_effect=RuntimeError("boom"))
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            outcome = extract_one_url(_row(page_type="HOME"))
+        finally:
+            for p in patches.values():
+                p.stop()
+        assert outcome.ok
+        mocks["mark"].assert_called_once()
+
+    def test_non_home_page_skips_description(self):
+        from extraction import extract_one_url
+        patches = _patches(pubs=[])
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            extract_one_url(_row(page_type="PUBLICATIONS"))
+        finally:
+            for p in patches.values():
+                p.stop()
+        mocks["extract_desc"].assert_not_called()

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -9,7 +9,7 @@ os.environ.setdefault("GOOGLE_API_KEY", "test-google-key")
 os.environ.setdefault("SCRAPE_API_KEY", "test-key")
 os.environ.setdefault("CONTENT_MAX_CHARS", "20000")
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -168,3 +168,20 @@ class TestExtractOneUrl:
             for p in patches.values():
                 p.stop()
         mocks["extract_desc"].assert_not_called()
+
+    def test_save_exception_propagates_and_does_not_mark(self):
+        """Mid-sequence persistence errors propagate (caller counts a failure);
+        the URL stays unmarked so it is retried. Retry is safe: saves dedup
+        via INSERT IGNORE + title_hash."""
+        from extraction import extract_one_url
+        patches = _patches(pubs=[{"title": "P"}])
+        patches["save"] = patch(
+            "extraction.Publication.save_publications", side_effect=RuntimeError("db down"))
+        mocks = {k: p.start() for k, p in patches.items()}
+        try:
+            with pytest.raises(RuntimeError):
+                extract_one_url(_row())
+        finally:
+            for p in patches.values():
+                p.stop()
+        mocks["mark"].assert_not_called()

--- a/tests/test_html_fetcher.py
+++ b/tests/test_html_fetcher.py
@@ -431,3 +431,36 @@ class TestNormalizationIntegration:
         new_text = "Paper A, accepted at AER"
         assert HTMLFetcher.hash_text_content(HTMLFetcher.normalize_text(old_text)) != \
                HTMLFetcher.hash_text_content(HTMLFetcher.normalize_text(new_text))
+
+
+class TestMarkExtractedWithHash:
+    """mark_extracted records the hash read at extraction start, not mark time."""
+
+    def test_explicit_hash_is_written(self):
+        with patch("html_fetcher.Database.execute_query") as mock_exec:
+            HTMLFetcher.mark_extracted(7, "abc123")
+        query, params = mock_exec.call_args[0]
+        assert "extracted_hash = %s" in query
+        assert params[1] == "abc123"
+        assert params[2] == 7
+
+    def test_no_hash_falls_back_to_content_hash(self):
+        """Legacy callers (batch_check) keep the old copy-current-hash behavior."""
+        with patch("html_fetcher.Database.execute_query") as mock_exec:
+            HTMLFetcher.mark_extracted(7)
+        query, params = mock_exec.call_args[0]
+        assert "extracted_hash = content_hash" in query
+        assert params[1] == 7
+
+
+class TestGetExtractionPayload:
+    def test_returns_row(self):
+        row = {"content": "text", "raw_html": "<html>", "content_hash": "h1"}
+        with patch("html_fetcher.Database.fetch_one", return_value=row) as mock_fetch:
+            result = HTMLFetcher.get_extraction_payload(7)
+        assert result == row
+        assert mock_fetch.call_args[0][1] == (7,)
+
+    def test_returns_none_when_no_html(self):
+        with patch("html_fetcher.Database.fetch_one", return_value=None):
+            assert HTMLFetcher.get_extraction_payload(7) is None

--- a/tests/test_publication_extraction.py
+++ b/tests/test_publication_extraction.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from openai import OpenAIError
 
+from llm_client import StructuredResponse
 from publication import Publication, PublicationExtraction, PublicationExtractionList, clean_title, reconcile_title_renames
 from paper_saver import _title_similarity
 
@@ -508,3 +509,58 @@ class TestReconcileTitleRenames:
         assert mock_emit.call_count == 2
         mock_emit.assert_any_call(10, "Old A", "New A")
         mock_emit.assert_any_call(20, "Old B", "New B")
+
+
+# ---------------------------------------------------------------------------
+# 7. try_extract_publications()
+# ---------------------------------------------------------------------------
+
+class TestTryExtractPublications:
+    """try_extract_publications distinguishes LLM failure (None) from empty ([])."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_content_max(self):
+        """CONTENT_MAX_CHARS is read from env as a string at import time.
+        Patch it to an int so text_content[:CONTENT_MAX_CHARS] works."""
+        with patch("publication.CONTENT_MAX_CHARS", 20000):
+            yield
+
+    def test_returns_none_on_llm_failure(self):
+        """parsed=None (API error / validation failure) → None, not []."""
+        failed = StructuredResponse(parsed=None, usage=None)
+        with patch("publication.extract_json", return_value=failed), \
+             patch("publication.Database.log_llm_usage"):
+            result = Publication.try_extract_publications("some text", "https://x.com")
+        assert result is None
+
+    def test_returns_empty_list_when_no_pubs_found(self):
+        """A valid response with zero publications → [] (genuine empty)."""
+        parsed = PublicationExtractionList(publications=[])
+        ok = StructuredResponse(parsed=parsed, usage=MagicMock())
+        with patch("publication.extract_json", return_value=ok), \
+             patch("publication.Database.log_llm_usage"):
+            result = Publication.try_extract_publications("some text", "https://x.com")
+        assert result == []
+
+    def test_returns_validated_pubs(self):
+        """Valid publications are returned as dicts."""
+        parsed = PublicationExtractionList.model_validate(
+            {"publications": [{"title": "A Great Paper", "authors": [["Jane", "Doe"]],
+                               "year": "2024", "venue": None, "status": None,
+                               "draft_url": None, "abstract": None}]}
+        )
+        ok = StructuredResponse(parsed=parsed, usage=MagicMock())
+        with patch("publication.extract_json", return_value=ok), \
+             patch("publication.Database.log_llm_usage"), \
+             patch("publication.validate_publication", return_value=True):
+            result = Publication.try_extract_publications("text", "https://x.com")
+        assert len(result) == 1
+        assert result[0]["title"] == "A Great Paper"
+
+    def test_extract_publications_returns_empty_list_on_failure(self):
+        """The legacy wrapper still returns [] (not None) on failure."""
+        failed = StructuredResponse(parsed=None, usage=None)
+        with patch("publication.extract_json", return_value=failed), \
+             patch("publication.Database.log_llm_usage"):
+            result = Publication.extract_publications("some text", "https://x.com")
+        assert result == []

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -765,3 +765,77 @@ class TestStartStopExtractionWorker:
     def test_stop_when_not_running_is_noop(self):
         scheduler._extraction_thread = None
         stop_extraction_worker()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# 12. Scheduler lifecycle — extraction worker
+# ---------------------------------------------------------------------------
+
+class TestSchedulerStartsExtractionWorker:
+    """Extraction worker starts/stops with the scheduler when enabled."""
+
+    def teardown_method(self):
+        import scheduler
+        scheduler._scheduler = None
+        scheduler._scheduler_lock_conn = None
+
+    def test_starts_extraction_worker_when_enabled(self):
+        with patch("scheduler.mysql.connector.connect") as mock_connect, \
+             patch("scheduler._cleanup_stale_scrape_logs"), \
+             patch("scheduler.BackgroundScheduler"), \
+             patch("scheduler.start_extraction_worker") as mock_start_worker, \
+             patch("scheduler.signal.signal"), \
+             patch.object(scheduler, 'EXTRACTION_WORKER_ENABLED', True), \
+             patch.object(scheduler, 'ENRICHMENT_WORKER_ENABLED', False), \
+             patch.object(scheduler, '_scheduler', None), \
+             patch.object(scheduler, '_scheduler_lock_conn', None):
+
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_cursor.fetchone.return_value = (1,)
+            mock_conn.cursor.return_value = mock_cursor
+            mock_connect.return_value = mock_conn
+
+            from scheduler import start_scheduler
+            start_scheduler()
+
+            mock_start_worker.assert_called_once()
+
+            scheduler._scheduler = None
+            scheduler._scheduler_lock_conn = None
+
+    def test_skips_extraction_worker_when_disabled(self):
+        with patch("scheduler.mysql.connector.connect") as mock_connect, \
+             patch("scheduler._cleanup_stale_scrape_logs"), \
+             patch("scheduler.BackgroundScheduler"), \
+             patch("scheduler.start_extraction_worker") as mock_start_worker, \
+             patch("scheduler.signal.signal"), \
+             patch.object(scheduler, 'EXTRACTION_WORKER_ENABLED', False), \
+             patch.object(scheduler, 'ENRICHMENT_WORKER_ENABLED', False), \
+             patch.object(scheduler, '_scheduler', None), \
+             patch.object(scheduler, '_scheduler_lock_conn', None):
+
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_cursor.fetchone.return_value = (1,)
+            mock_conn.cursor.return_value = mock_cursor
+            mock_connect.return_value = mock_conn
+
+            from scheduler import start_scheduler
+            start_scheduler()
+
+            mock_start_worker.assert_not_called()
+
+            scheduler._scheduler = None
+            scheduler._scheduler_lock_conn = None
+
+    def test_shutdown_stops_extraction_worker(self):
+        with patch("scheduler.stop_extraction_worker") as mock_stop_worker, \
+             patch("scheduler.stop_enrichment_worker"):
+            scheduler._scheduler = MagicMock()
+            scheduler._scheduler_lock_conn = MagicMock()
+
+            from scheduler import shutdown_scheduler
+            shutdown_scheduler()
+
+            mock_stop_worker.assert_called_once()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -41,18 +41,8 @@ def _base_patches():
         "update_progress": patch("scheduler._update_progress"),
         "get_urls": patch("scheduler.Researcher.get_all_researcher_urls", return_value=[]),
         "validate": patch("scheduler._validate_draft_urls"),
-        "get_prev": patch("scheduler.HTMLFetcher.get_previous_text", return_value=None),
         "fetch": patch("scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=False),
-        "get_latest": patch("scheduler.HTMLFetcher.get_latest_text", return_value=""),
-        "compute_diff": patch("scheduler.HTMLFetcher.compute_diff", return_value="diff text"),
-        "extract_desc": patch("scheduler.HTMLFetcher.extract_description", return_value=None),
-        "extract_pubs": patch("scheduler.Publication.extract_publications", return_value=[]),
-        "save_pubs": patch("scheduler.Publication.save_publications"),
-        "match_links": patch("scheduler.match_and_save_paper_links"),
         "fetch_one": patch("scheduler.Database.fetch_one", return_value=None),
-        "paper_snap": patch("scheduler.append_snapshots_for_pubs"),
-        "researcher_snap": patch("scheduler.Database.append_researcher_snapshot"),
-        "reconcile_renames": patch("scheduler.reconcile_title_renames"),
     }
 
 
@@ -72,7 +62,7 @@ class TestRunScrapeJobHappyPath:
 
             mocks["acquire"].assert_called_once()
             mocks["create_log"].assert_called_once()
-            mocks["update_log"].assert_called_once_with(42, "completed", 0, 0, 0, 0, None)
+            mocks["update_log"].assert_called_once_with(42, "completed", 0, 0)
             mocks["validate"].assert_called_once()
             mocks["release"].assert_called_once()
         finally:
@@ -92,38 +82,23 @@ class TestRunScrapeJobHappyPath:
                 p.stop()
 
     def test_happy_path_with_changed_url(self):
-        """One URL changes, publications extracted and saved, log reflects counts."""
-        url_row = _make_url_row()
-        pubs = [{"title": "My Paper", "status": "published", "venue": "AER",
-                 "abstract": "...", "draft_url": None, "year": "2025"}]
-
+        """A changed URL increments urls_changed; no extraction happens in the scrape job."""
         patches = _base_patches()
         patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=[url_row]
-        )
+            "scheduler.Researcher.get_all_researcher_urls",
+            return_value=[_make_url_row()])
         patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="page content"
-        )
-        patches["extract_pubs"] = patch(
-            "scheduler.Publication.extract_publications", return_value=pubs
-        )
-
+            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True)
         mocks = {name: p.start() for name, p in patches.items()}
         try:
             run_scrape_job()
-
-            mocks["extract_pubs"].assert_called_once()
-            mocks["save_pubs"].assert_called_once_with(
-                url_row["url"], pubs, is_seed=True,
-            )
-            mocks["paper_snap"].assert_called_once_with(pubs, url_row["url"])
-            mocks["update_log"].assert_called_once_with(42, "completed", 1, 1, 1, 0, None)
         finally:
             for p in patches.values():
                 p.stop()
+        args = mocks["update_log"].call_args[0]
+        assert args[1] == "completed"
+        assert args[2] == 1  # urls_checked
+        assert args[3] == 1  # urls_changed
 
 
 # ---------------------------------------------------------------------------
@@ -254,87 +229,6 @@ class TestLockReleaseOnError:
 class TestURLProcessing:
     """Changed URLs trigger extraction; unchanged URLs do not."""
 
-    def test_unchanged_url_skips_extraction(self):
-        url_row = _make_url_row()
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=[url_row]
-        )
-        # fetch returns False => unchanged
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=False
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            run_scrape_job()
-
-            mocks["get_prev"].assert_called_once_with(url_row["id"])
-            mocks["fetch"].assert_called_once()
-            mocks["get_latest"].assert_not_called()
-            mocks["extract_pubs"].assert_not_called()
-            mocks["update_log"].assert_called_once_with(42, "completed", 1, 0, 0, 0, None)
-        finally:
-            for p in patches.values():
-                p.stop()
-
-    def test_changed_url_with_old_text_uses_diff(self):
-        """When old content exists, compute_diff is called and its result passed to extraction."""
-        url_row = _make_url_row()
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=[url_row]
-        )
-        patches["get_prev"] = patch(
-            "scheduler.HTMLFetcher.get_previous_text", return_value="old content"
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="new content"
-        )
-        patches["compute_diff"] = patch(
-            "scheduler.HTMLFetcher.compute_diff", return_value="the diff"
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            run_scrape_job()
-
-            mocks["compute_diff"].assert_called_once_with("old content", "new content")
-            mocks["extract_pubs"].assert_called_once()
-            # First positional arg to extract_publications should be the diff
-            assert mocks["extract_pubs"].call_args[0][0] == "the diff"
-        finally:
-            for p in patches.values():
-                p.stop()
-
-    def test_first_scrape_uses_full_text_not_diff(self):
-        """On first scrape (old_text is None), full new text is used directly."""
-        url_row = _make_url_row()
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=[url_row]
-        )
-        patches["get_prev"] = patch(
-            "scheduler.HTMLFetcher.get_previous_text", return_value=None
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="full page text"
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            run_scrape_job()
-
-            mocks["compute_diff"].assert_not_called()
-            mocks["extract_pubs"].assert_called_once()
-            assert mocks["extract_pubs"].call_args[0][0] == "full page text"
-        finally:
-            for p in patches.values():
-                p.stop()
-
     def test_per_url_exception_continues_to_next(self):
         """An exception processing one URL should not abort the whole scrape."""
         url1 = _make_url_row(url_id=1, url="https://example.com/a")
@@ -344,126 +238,20 @@ class TestURLProcessing:
         patches["get_urls"] = patch(
             "scheduler.Researcher.get_all_researcher_urls", return_value=[url1, url2]
         )
-        # First URL's get_previous_text raises, second one succeeds
-        patches["get_prev"] = patch(
-            "scheduler.HTMLFetcher.get_previous_text",
-            side_effect=[RuntimeError("timeout"), None],
-        )
         patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=False
+            "scheduler.HTMLFetcher.fetch_and_save_if_changed",
+            side_effect=[RuntimeError("timeout"), False],
         )
         mocks = {name: p.start() for name, p in patches.items()}
         try:
             run_scrape_job()
 
-            # fetch should be called for url2 even though url1 failed
-            assert mocks["fetch"].call_count == 1
+            # fetch was attempted for both urls; url1 raised, url2 succeeded
+            assert mocks["fetch"].call_count == 2
             # Log should show completed (per-URL errors are caught)
-            mocks["update_log"].assert_called_once_with(42, "completed", 2, 0, 0, 0, None)
-        finally:
-            for p in patches.values():
-                p.stop()
-
-    def test_home_page_extracts_description_on_change(self):
-        """HOME page type triggers description extraction when content changed."""
-        url_row = _make_url_row(page_type="HOME")
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=[url_row]
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="homepage text"
-        )
-        patches["extract_desc"] = patch(
-            "scheduler.HTMLFetcher.extract_description", return_value="A labor economist."
-        )
-        patches["fetch_one"] = patch(
-            "scheduler.Database.fetch_one",
-            return_value={"position": "Professor", "affiliation": "MIT"},
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            run_scrape_job()
-
-            mocks["extract_desc"].assert_called_once()
-            mocks["researcher_snap"].assert_called_once_with(
-                url_row["researcher_id"], "Professor", "MIT",
-                "A labor economist.", source_url=url_row["url"],
-            )
-        finally:
-            for p in patches.values():
-                p.stop()
-
-    def test_home_page_no_description_skips_snapshot(self):
-        """HOME page where extract_description returns None should not append snapshot."""
-        url_row = _make_url_row(page_type="HOME")
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=[url_row]
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="homepage text"
-        )
-        patches["extract_desc"] = patch(
-            "scheduler.HTMLFetcher.extract_description", return_value=None
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            run_scrape_job()
-
-            mocks["extract_desc"].assert_called_once()
-            mocks["researcher_snap"].assert_not_called()
-        finally:
-            for p in patches.values():
-                p.stop()
-
-    def test_unchanged_home_page_skips_description(self):
-        """HOME page that didn't change should NOT re-extract description."""
-        url_row = _make_url_row(page_type="HOME")
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=[url_row]
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=False
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            run_scrape_job()
-
-            mocks["extract_desc"].assert_not_called()
-        finally:
-            for p in patches.values():
-                p.stop()
-
-    def test_snapshots_called_with_pubs(self):
-        """append_snapshots_for_pubs is called with extracted publications."""
-        url_row = _make_url_row()
-        pubs = [{"title": "Ghost Paper", "status": "published"}]
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=[url_row]
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="text"
-        )
-        patches["extract_pubs"] = patch(
-            "scheduler.Publication.extract_publications", return_value=pubs
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            run_scrape_job()
-
-            mocks["paper_snap"].assert_called_once_with(pubs, url_row["url"])
+            args = mocks["update_log"].call_args[0]
+            assert args[1] == "completed"
+            assert args[2] == 2  # urls_checked
         finally:
             for p in patches.values():
                 p.stop()
@@ -529,189 +317,30 @@ class TestUpdateScrapeLog:
 
 
 # ---------------------------------------------------------------------------
-# 7. Phase separation — fetch before extract
+# 7. Scrape job is fetch-only
 # ---------------------------------------------------------------------------
 
-class TestPhaseSeparation:
-    """Verify all URLs are fetched before any extraction begins."""
-
-    def test_fetch_runs_before_any_extraction(self):
-        """All fetch calls complete before any extract_publications call."""
-        url_rows = [
-            _make_url_row(url_id=1, url="http://a.com"),
-            _make_url_row(url_id=2, url="http://b.com"),
-        ]
+class TestScrapeJobIsFetchOnly:
+    def test_scrape_never_calls_llm_extraction(self):
+        """run_scrape_job must not extract — the worker owns extraction."""
         patches = _base_patches()
         patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
-        )
+            "scheduler.Researcher.get_all_researcher_urls",
+            return_value=[_make_url_row()])
         patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
-        )
-        patches["extract_pubs"] = patch(
-            "scheduler.Publication.extract_publications",
-            return_value=[{"title": "P", "status": "published"}],
-        )
-
-        call_order = []
-
+            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True)
         mocks = {name: p.start() for name, p in patches.items()}
         try:
-            orig_fetch = mocks["fetch"].side_effect
-            mocks["fetch"].side_effect = lambda *a, **kw: (call_order.append("fetch"), True)[1]
-            mocks["extract_pubs"].side_effect = lambda *a, **kw: (call_order.append("extract"), [{"title": "P"}])[1]
-
-            run_scrape_job()
-
-            fetch_indices = [i for i, c in enumerate(call_order) if c == "fetch"]
-            extract_indices = [i for i, c in enumerate(call_order) if c == "extract"]
-            assert len(fetch_indices) > 0
-            assert len(extract_indices) > 0
-            assert max(fetch_indices) < min(extract_indices)
-        finally:
-            for p in patches.values():
-                p.stop()
-
-    def test_all_urls_fetched_when_extraction_fails(self):
-        """All URLs are fetched even when extraction returns empty for all."""
-        url_rows = [
-            _make_url_row(url_id=i, url=f"http://r{i}.com")
-            for i in range(1, 6)
-        ]
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            run_scrape_job()
-            assert mocks["fetch"].call_count == 5
+            with patch("publication.Publication.try_extract_publications") as mock_llm:
+                run_scrape_job()
+                mock_llm.assert_not_called()
         finally:
             for p in patches.values():
                 p.stop()
 
 
 # ---------------------------------------------------------------------------
-# 8. Extraction circuit breaker
-# ---------------------------------------------------------------------------
-
-class TestExtractionCircuitBreaker:
-    """Verify circuit breaker stops extraction after consecutive failures."""
-
-    def test_stops_after_threshold_consecutive_failures(self):
-        url_rows = [
-            _make_url_row(url_id=i, url=f"http://r{i}.com")
-            for i in range(1, 21)
-        ]
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
-        )
-        # extract always returns empty (quota failure)
-        patches["extract_pubs"] = patch(
-            "scheduler.Publication.extract_publications", return_value=[],
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            from scheduler import _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD
-            run_scrape_job()
-
-            # All 20 fetched
-            assert mocks["fetch"].call_count == 20
-            # Extraction stops at threshold
-            assert mocks["extract_pubs"].call_count == _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD
-        finally:
-            for p in patches.values():
-                p.stop()
-
-    def test_resets_on_successful_extraction(self):
-        """A successful extraction resets the consecutive failure counter."""
-        url_rows = [
-            _make_url_row(url_id=i, url=f"http://r{i}.com")
-            for i in range(1, 21)
-        ]
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
-        )
-
-        # Fail 5 times, succeed on 6th, repeat — never hits 10 consecutive
-        call_count = [0]
-        def alternating(*a, **kw):
-            call_count[0] += 1
-            if call_count[0] % 6 == 0:
-                return [{"title": "Paper", "status": "published"}]
-            return []
-
-        patches["extract_pubs"] = patch(
-            "scheduler.Publication.extract_publications", side_effect=alternating,
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            run_scrape_job()
-            # All 20 extracted (no circuit break)
-            assert mocks["extract_pubs"].call_count == 20
-        finally:
-            for p in patches.values():
-                p.stop()
-
-    def test_records_error_message_when_tripped(self):
-        """Circuit breaker sets error_message on scrape_log."""
-        url_rows = [
-            _make_url_row(url_id=i, url=f"http://r{i}.com")
-            for i in range(1, 15)
-        ]
-        patches = _base_patches()
-        patches["get_urls"] = patch(
-            "scheduler.Researcher.get_all_researcher_urls", return_value=url_rows,
-        )
-        patches["fetch"] = patch(
-            "scheduler.HTMLFetcher.fetch_and_save_if_changed", return_value=True,
-        )
-        patches["get_latest"] = patch(
-            "scheduler.HTMLFetcher.get_latest_text", return_value="text",
-        )
-        patches["extract_pubs"] = patch(
-            "scheduler.Publication.extract_publications", return_value=[],
-        )
-        mocks = {name: p.start() for name, p in patches.items()}
-        try:
-            from scheduler import _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD
-            run_scrape_job()
-
-            mocks["update_log"].assert_called_once()
-            args = mocks["update_log"].call_args[0]
-            assert args[1] == "completed"  # status still completed (fetch did finish)
-            assert args[5] == _EXTRACTION_CIRCUIT_BREAKER_THRESHOLD  # extraction_errors
-            assert "circuit-breaker" in args[6].lower()  # error_message
-        finally:
-            for p in patches.values():
-                p.stop()
-
-
-# ---------------------------------------------------------------------------
-# 9. Stale scrape_log cleanup
+# 8. Stale scrape_log cleanup
 # ---------------------------------------------------------------------------
 
 class TestStaleLogCleanup:
@@ -739,7 +368,7 @@ class TestStaleLogCleanup:
 
 
 # ---------------------------------------------------------------------------
-# 10. Enrichment worker
+# 9. Enrichment worker
 # ---------------------------------------------------------------------------
 
 class TestEnrichmentWorkerLoop:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -13,6 +13,7 @@ from scheduler import (
     run_scrape_job, create_scrape_log, update_scrape_log,
     _cleanup_stale_scrape_logs,
     _enrichment_worker_loop, start_enrichment_worker, stop_enrichment_worker,
+    _extraction_worker_loop, start_extraction_worker, stop_extraction_worker,
 )
 
 
@@ -566,3 +567,201 @@ class TestSchedulerStartsEnrichmentWorker:
             shutdown_scheduler()
 
             mock_stop_worker.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 11. Extraction worker
+# ---------------------------------------------------------------------------
+
+def _outcome(status, pubs_count=0):
+    from extraction import ExtractionOutcome
+    return ExtractionOutcome(status, pubs_count=pubs_count)
+
+
+class TestExtractionWorkerLoop:
+    """Tests for the continuous extraction background worker."""
+
+    def setup_method(self):
+        scheduler._extraction_stop_event.clear()
+
+    def teardown_method(self):
+        scheduler._extraction_stop_event.clear()
+
+    def test_processes_pending_urls(self):
+        rows = [_make_url_row(url_id=1), _make_url_row(url_id=2)]
+        processed = []
+
+        def fake_extract(row, scrape_log_id=None):
+            processed.append(row["id"])
+            if len(processed) >= 2:
+                scheduler._extraction_stop_event.set()
+            return _outcome("extracted", pubs_count=3)
+
+        with patch("scheduler.Database.get_urls_needing_extraction", return_value=rows), \
+             patch("extraction.extract_one_url", side_effect=fake_extract), \
+             patch.object(scheduler, "_EXTRACTION_DELAY_SECONDS", 0):
+            _extraction_worker_loop()
+
+        assert processed == [1, 2]
+
+    def test_idles_when_queue_empty(self):
+        calls = [0]
+
+        def empty_then_stop():
+            calls[0] += 1
+            if calls[0] >= 2:
+                scheduler._extraction_stop_event.set()
+            return []
+
+        waits = []
+
+        def record_wait(timeout=None):
+            waits.append(timeout)
+            return scheduler._extraction_stop_event.is_set()
+
+        with patch("scheduler.Database.get_urls_needing_extraction", side_effect=empty_then_stop), \
+             patch.object(scheduler._extraction_stop_event, "wait", side_effect=record_wait):
+            _extraction_worker_loop()
+
+        assert scheduler._EXTRACTION_IDLE_SECONDS in waits
+
+    def test_skips_url_after_max_failures(self):
+        """A URL that fails 3 times is excluded until restart (poison-pill guard)."""
+        rows = [_make_url_row(url_id=1)]
+        attempts = [0]
+        scans = [0]
+
+        def failing(row, scrape_log_id=None):
+            attempts[0] += 1
+            return _outcome("failed")
+
+        def get_queue():
+            scans[0] += 1
+            if scans[0] >= 6:
+                scheduler._extraction_stop_event.set()
+            return rows
+
+        with patch("scheduler.Database.get_urls_needing_extraction", side_effect=get_queue), \
+             patch("extraction.extract_one_url", side_effect=failing), \
+             patch.object(scheduler, "_EXTRACTION_DELAY_SECONDS", 0), \
+             patch.object(scheduler, "_EXTRACTION_IDLE_SECONDS", 0), \
+             patch.object(scheduler, "_EXTRACTION_BACKOFF_THRESHOLD", 99):
+            _extraction_worker_loop()
+
+        assert attempts[0] == 3  # 4th+ scans filter the URL out
+
+    def test_backs_off_after_threshold_consecutive_failures(self):
+        rows = [_make_url_row(url_id=i) for i in range(1, 5)]
+        count = [0]
+
+        def failing(row, scrape_log_id=None):
+            count[0] += 1
+            if count[0] >= 4:
+                scheduler._extraction_stop_event.set()
+            return _outcome("failed")
+
+        waits = []
+
+        def record_wait(timeout=None):
+            waits.append(timeout)
+            return scheduler._extraction_stop_event.is_set()
+
+        with patch("scheduler.Database.get_urls_needing_extraction", return_value=rows), \
+             patch("extraction.extract_one_url", side_effect=failing), \
+             patch.object(scheduler, "_EXTRACTION_BACKOFF_THRESHOLD", 3), \
+             patch.object(scheduler, "_EXTRACTION_MAX_URL_FAILURES", 99), \
+             patch.object(scheduler._extraction_stop_event, "wait", side_effect=record_wait):
+            _extraction_worker_loop()
+
+        assert scheduler._EXTRACTION_BACKOFF_SECONDS in waits
+
+    def test_success_resets_consecutive_failures(self):
+        rows = [_make_url_row(url_id=i) for i in range(1, 5)]
+        count = [0]
+
+        def fail_fail_succeed(row, scrape_log_id=None):
+            count[0] += 1
+            if count[0] >= 4:
+                scheduler._extraction_stop_event.set()
+            if count[0] == 3:
+                return _outcome("extracted", pubs_count=1)
+            return _outcome("failed")
+
+        waits = []
+
+        def record_wait(timeout=None):
+            waits.append(timeout)
+            return scheduler._extraction_stop_event.is_set()
+
+        with patch("scheduler.Database.get_urls_needing_extraction", return_value=rows), \
+             patch("extraction.extract_one_url", side_effect=fail_fail_succeed), \
+             patch.object(scheduler, "_EXTRACTION_BACKOFF_THRESHOLD", 3), \
+             patch.object(scheduler, "_EXTRACTION_MAX_URL_FAILURES", 99), \
+             patch.object(scheduler._extraction_stop_event, "wait", side_effect=record_wait):
+            _extraction_worker_loop()
+
+        # Success at call 3 reset the counter, so the threshold (3) was never
+        # reached and no backoff wait happened.
+        assert scheduler._EXTRACTION_BACKOFF_SECONDS not in waits
+
+    def test_unexpected_exception_counts_as_failure(self):
+        rows = [_make_url_row(url_id=1)]
+        count = [0]
+
+        def exploding(row, scrape_log_id=None):
+            count[0] += 1
+            if count[0] >= 2:
+                scheduler._extraction_stop_event.set()
+            raise RuntimeError("DB down")
+
+        with patch("scheduler.Database.get_urls_needing_extraction", return_value=rows), \
+             patch("extraction.extract_one_url", side_effect=exploding), \
+             patch.object(scheduler, "_EXTRACTION_DELAY_SECONDS", 0), \
+             patch.object(scheduler, "_EXTRACTION_IDLE_SECONDS", 0), \
+             patch.object(scheduler, "_EXTRACTION_MAX_URL_FAILURES", 99), \
+             patch.object(scheduler, "_EXTRACTION_BACKOFF_THRESHOLD", 99):
+            _extraction_worker_loop()  # must not raise
+
+        assert count[0] == 2
+
+
+class TestStartStopExtractionWorker:
+    def test_start_creates_daemon_thread(self):
+        with patch("scheduler.threading.Thread") as mock_thread_cls:
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            start_extraction_worker()
+
+            mock_thread_cls.assert_called_once()
+            assert mock_thread_cls.call_args[1]["daemon"] is True
+            assert mock_thread_cls.call_args[1]["name"] == "extraction-worker"
+            mock_thread.start.assert_called_once()
+
+            scheduler._extraction_thread = None
+            scheduler._extraction_stop_event.clear()
+
+    def test_start_is_idempotent(self):
+        scheduler._extraction_thread = MagicMock(is_alive=MagicMock(return_value=True))
+        try:
+            with patch("scheduler.threading.Thread") as mock_thread_cls:
+                start_extraction_worker()
+                mock_thread_cls.assert_not_called()
+        finally:
+            scheduler._extraction_thread = None
+
+    def test_stop_sets_event_and_joins(self):
+        mock_thread = MagicMock()
+        scheduler._extraction_thread = mock_thread
+        scheduler._extraction_stop_event.clear()
+
+        stop_extraction_worker()
+
+        assert scheduler._extraction_stop_event.is_set()
+        mock_thread.join.assert_called_once_with(timeout=30)
+        assert scheduler._extraction_thread is None
+        scheduler._extraction_stop_event.clear()
+
+    def test_stop_when_not_running_is_noop(self):
+        scheduler._extraction_thread = None
+        stop_extraction_worker()  # should not raise


### PR DESCRIPTION
## Summary

- **New continuous extraction worker**: a daemon thread in the API process (mirroring the enrichment worker, gated by `EXTRACTION_WORKER_ENABLED`) drains the `content_hash ≠ extracted_hash` queue with synchronous free-tier Gemma calls. Measured pacing: calls are latency-bound at 45–190s (~35 output tok/s, hard 30 RPM cap), so the worker self-paces; a 2s delay (`EXTRACTION_DELAY_SECONDS`) guards the fast tail. 5-min idle poll, 10-min backoff after 10 consecutive failures (rides out daily quota exhaustion unattended), per-URL poison-pill skip after 3 failed attempts.
- **`run_scrape_job()` is now fetch-only** — the diff-based extract phase and its circuit breaker move out (same split previously done for enrichment). Per-URL extraction logic is consolidated in a new shared `extraction.py` (`extract_one_url`), used by the worker and the `make extract` CLI, including the HOME-page description refresh.
- **Correctness fixes along the way**: `mark_extracted` now records the content hash read at extraction *start* (a fetch landing mid-extraction is no longer silently marked extracted); `try_extract_publications` distinguishes LLM failure (retry) from genuinely-empty pages (mark done); single-query extraction queue replaces ~10k per-URL `needs_extraction` calls per scan.
- **Deploy plumbing**: `extraction.py` whitelisted in `.dockerignore`, env vars in `.env.example`, CLAUDE.md pipeline docs rewritten, `make extract` target added.

Design spec with measured pacing data: `docs/superpowers/specs/2026-06-09-extraction-background-worker-design.md` (branch `docs-extraction-worker-spec`).

## Prod rollout (after merge)

1. On Lightsail, edit `/opt/econ-newsfeed/.env`: set `LLM_MODEL=gemma-4-31b-it` (or remove the line — it's the code default) and add `EXTRACTION_WORKER_ENABLED=true`.
2. `cd /opt/econ-newsfeed && ./scripts/deploy.sh`
3. `docker compose logs -f api | grep -i "extraction worker"` — expect "Extraction worker started" and steady progress. The ~9.7k-page backlog drains in roughly 7–10 days at measured free-tier latency.

## Test Plan

- [x] 871 Python tests pass (10 new worker tests, 10 extraction tests, lifecycle wiring tests, fetch-only guarantee test)
- [x] `tsc --noEmit` clean, 92 frontend tests pass
- [x] Import smoke test (`from extraction import ...`, `from scheduler import start_extraction_worker`)
- [ ] After deploy: verify worker log lines and `llm_usage` rows accumulating in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)