### PR TITLE
feat: extraction worker surveillance tab in admin dashboard

### DIFF
--- a/app/src/app/admin/AdminDashboard.tsx
+++ b/app/src/app/admin/AdminDashboard.tsx
@@ -9,6 +9,7 @@ import QualityTab from "./tabs/QualityTab";
 import CostsTab from "./tabs/CostsTab";
 import ScrapesTab from "./tabs/ScrapesTab";
 import ActivityTab from "./tabs/ActivityTab";
+import ExtractionTab from "./tabs/ExtractionTab";
 
 const TABS = [
   { id: "health", label: "Health" },
@@ -17,6 +18,7 @@ const TABS = [
   { id: "costs", label: "Costs" },
   { id: "scrapes", label: "Scrapes" },
   { id: "activity", label: "Activity" },
+  { id: "extraction", label: "Extraction" },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
@@ -98,6 +100,7 @@ export default function AdminDashboard() {
             {activeTab === "costs" && <CostsTab data={data.costs} />}
             {activeTab === "scrapes" && <ScrapesTab data={data.scrapes} />}
             {activeTab === "activity" && <ActivityTab data={data.activity} />}
+            {activeTab === "extraction" && <ExtractionTab data={data.extraction} />}
           </>
         ) : null}
       </div>

--- a/app/src/app/admin/__tests__/ExtractionTab.test.tsx
+++ b/app/src/app/admin/__tests__/ExtractionTab.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import ExtractionTab from "../tabs/ExtractionTab";
+import type { AdminDashboardData } from "@/lib/api";
+
+function fixture(overrides: Partial<AdminDashboardData["extraction"]> = {}): AdminDashboardData["extraction"] {
+  return {
+    worker_enabled: true,
+    queue: { never_extracted: 6000, changed_pending: 4000, total: 10000 },
+    throughput: {
+      completions: { last_hour: 40, last_24h: 1000, last_7d: 5000 },
+      attempts: { last_hour: 42, last_24h: 1050, last_7d: 5200 },
+    },
+    eta_days: 10.0,
+    last_call_at: new Date().toISOString(),
+    last_extracted_at: new Date().toISOString(),
+    tokens_last_24h: 412345,
+    daily: [{ date: "2026-06-10", count: 950 }],
+    recent_calls: [
+      {
+        called_at: new Date().toISOString(),
+        context_url: "https://example.com/pubs",
+        model: "gemma-4-31b-it",
+        total_tokens: 4102,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("ExtractionTab", () => {
+  it("renders queue, ETA, and throughput numbers", () => {
+    render(<ExtractionTab data={fixture()} />);
+    expect(screen.getByText("10,000")).toBeInTheDocument();
+    expect(screen.getByText(/~10 days/)).toBeInTheDocument();
+    // completions 24h appears in both the stat card and the throughput table
+    expect(screen.getAllByText("1,000").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/6,000 never/)).toBeInTheDocument();
+  });
+
+  it("shows enabled badge and no stall warning when recently active", () => {
+    render(<ExtractionTab data={fixture()} />);
+    expect(screen.getByText("Worker enabled")).toBeInTheDocument();
+    expect(screen.queryByText(/stalled/i)).not.toBeInTheDocument();
+  });
+
+  it("shows stalled warning when enabled, queue non-empty, no call in 30+ min", () => {
+    render(
+      <ExtractionTab
+        data={fixture({ last_call_at: "2020-01-01T00:00:00Z" })}
+      />
+    );
+    expect(screen.getByText(/stalled/i)).toBeInTheDocument();
+  });
+
+  it("shows disabled badge and no stall warning when worker disabled", () => {
+    render(
+      <ExtractionTab
+        data={fixture({ worker_enabled: false, last_call_at: null })}
+      />
+    );
+    expect(screen.getByText("Worker disabled")).toBeInTheDocument();
+    expect(screen.queryByText(/stalled/i)).not.toBeInTheDocument();
+  });
+
+  it("renders recent calls with model and tokens", () => {
+    render(<ExtractionTab data={fixture()} />);
+    expect(screen.getByText("https://example.com/pubs")).toBeInTheDocument();
+    expect(screen.getByText("gemma-4-31b-it")).toBeInTheDocument();
+  });
+
+  it("renders em-dash ETA when null", () => {
+    render(<ExtractionTab data={fixture({ eta_days: null })} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/app/src/app/admin/tabs/ExtractionTab.tsx
+++ b/app/src/app/admin/tabs/ExtractionTab.tsx
@@ -1,0 +1,175 @@
+import type { AdminDashboardData } from "@/lib/api";
+
+interface Props {
+  data: AdminDashboardData["extraction"];
+}
+
+const STALL_THRESHOLD_MS = 30 * 60 * 1000; // worker's worst healthy quiet period is the 10-min backoff
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatRelativeTime(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function isStalled(data: Props["data"]): boolean {
+  if (!data.worker_enabled || data.queue.total === 0) return false;
+  if (!data.last_call_at) return true;
+  return Date.now() - new Date(data.last_call_at).getTime() > STALL_THRESHOLD_MS;
+}
+
+export default function ExtractionTab({ data }: Props) {
+  const { queue, throughput, eta_days, tokens_last_24h, daily, recent_calls } = data;
+  const stalled = isStalled(data);
+
+  return (
+    <div className="space-y-6">
+      {/* Status row */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <span
+          className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded border ${
+            data.worker_enabled
+              ? "bg-emerald-900/50 text-emerald-400 border-emerald-800"
+              : "bg-zinc-800 text-zinc-400 border-zinc-700"
+          }`}
+        >
+          {data.worker_enabled ? "Worker enabled" : "Worker disabled"}
+        </span>
+        {stalled && (
+          <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded border bg-red-900/50 text-red-400 border-red-800">
+            Possibly stalled — no LLM call in 30+ min
+          </span>
+        )}
+        <span className="text-xs text-zinc-500">
+          Last call: {data.last_call_at ? formatRelativeTime(data.last_call_at) : "—"}
+          {" · "}
+          Last extraction: {data.last_extracted_at ? formatRelativeTime(data.last_extracted_at) : "—"}
+        </span>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-4 gap-4">
+        <div className="bg-[#1a1d27] rounded-lg border border-[#2a2d3a] p-5">
+          <p className="text-xs text-zinc-500 mb-1">Queue</p>
+          <p className="text-2xl font-semibold text-zinc-100">{queue.total.toLocaleString()}</p>
+          <p className="text-xs text-zinc-500 mt-1">
+            {queue.never_extracted.toLocaleString()} never · {queue.changed_pending.toLocaleString()} changed
+          </p>
+        </div>
+        <div className="bg-[#1a1d27] rounded-lg border border-[#2a2d3a] p-5">
+          <p className="text-xs text-zinc-500 mb-1">Extracted (24h)</p>
+          <p className="text-2xl font-semibold text-zinc-100">
+            {throughput.completions.last_24h.toLocaleString()}
+          </p>
+        </div>
+        <div className="bg-[#1a1d27] rounded-lg border border-[#2a2d3a] p-5">
+          <p className="text-xs text-zinc-500 mb-1">ETA to drain</p>
+          <p className="text-2xl font-semibold text-zinc-100">
+            {eta_days !== null ? `~${eta_days % 1 === 0 ? eta_days.toFixed(0) : eta_days} days` : "—"}
+          </p>
+        </div>
+        <div className="bg-[#1a1d27] rounded-lg border border-[#2a2d3a] p-5">
+          <p className="text-xs text-zinc-500 mb-1">Tokens (24h)</p>
+          <p className="text-2xl font-semibold text-zinc-100">{formatTokens(tokens_last_24h)}</p>
+        </div>
+      </div>
+
+      {/* Throughput */}
+      <div className="bg-[#1a1d27] rounded-lg border border-[#2a2d3a] p-5">
+        <h2 className="text-sm font-medium text-zinc-400 mb-4">Throughput</h2>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-zinc-500 border-b border-[#2a2d3a]">
+              <th className="text-left py-2 font-medium">Window</th>
+              <th className="text-right py-2 font-medium">Completed</th>
+              <th className="text-right py-2 font-medium">Attempts</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(["last_hour", "last_24h", "last_7d"] as const).map((w) => (
+              <tr key={w} className="border-b border-[#2a2d3a] last:border-0">
+                <td className="py-2 text-zinc-300">
+                  {w === "last_hour" ? "Last hour" : w === "last_24h" ? "Last 24h" : "Last 7 days"}
+                </td>
+                <td className="py-2 text-right text-zinc-100 font-medium">
+                  {throughput.completions[w].toLocaleString()}
+                </td>
+                <td className="py-2 text-right text-zinc-300">
+                  {throughput.attempts[w].toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="text-xs text-zinc-500 mt-2">
+          Attempts − completed ≈ failed/retried calls (quota exhaustion shows up here).
+        </p>
+      </div>
+
+      {/* Daily trend */}
+      <div className="bg-[#1a1d27] rounded-lg border border-[#2a2d3a] p-5">
+        <h2 className="text-sm font-medium text-zinc-400 mb-4">Extractions per Day (14d)</h2>
+        {daily.length === 0 ? (
+          <p className="text-sm text-zinc-500">No extractions in the last 14 days.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <tbody>
+              {daily.map((d) => (
+                <tr key={d.date} className="border-b border-[#2a2d3a] last:border-0">
+                  <td className="py-1.5 text-zinc-400">{d.date}</td>
+                  <td className="py-1.5 text-right text-zinc-100">{d.count.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Recent calls */}
+      <div className="bg-[#1a1d27] rounded-lg border border-[#2a2d3a] p-5">
+        <h2 className="text-sm font-medium text-zinc-400 mb-4">Recent Extraction Calls</h2>
+        {recent_calls.length === 0 ? (
+          <p className="text-sm text-zinc-500">No extraction calls recorded.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-zinc-500 border-b border-[#2a2d3a]">
+                  <th className="text-left py-2 font-medium">When</th>
+                  <th className="text-left py-2 font-medium">URL</th>
+                  <th className="text-left py-2 font-medium">Model</th>
+                  <th className="text-right py-2 font-medium">Tokens</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recent_calls.map((c, i) => (
+                  <tr key={`${c.called_at}-${i}`} className="border-b border-[#2a2d3a]/50 last:border-0">
+                    <td className="py-2 pr-3 text-zinc-500 whitespace-nowrap">
+                      {formatRelativeTime(c.called_at)}
+                    </td>
+                    <td className="py-2 pr-3 text-zinc-300 max-w-md truncate">
+                      {c.context_url ?? "—"}
+                    </td>
+                    <td className="py-2 pr-3 text-zinc-400">{c.model}</td>
+                    <td className="py-2 text-right text-zinc-300">{formatTokens(c.total_tokens)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/app/admin/tabs/ExtractionTab.tsx
+++ b/app/src/app/admin/tabs/ExtractionTab.tsx
@@ -158,8 +158,19 @@ export default function ExtractionTab({ data }: Props) {
                     <td className="py-2 pr-3 text-zinc-500 whitespace-nowrap">
                       {formatRelativeTime(c.called_at)}
                     </td>
-                    <td className="py-2 pr-3 text-zinc-300 max-w-md truncate">
-                      {c.context_url ?? "—"}
+                    <td className="py-2 pr-3 max-w-md truncate">
+                      {c.context_url ? (
+                        <a
+                          href={c.context_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-zinc-300 hover:text-zinc-100 hover:underline"
+                        >
+                          {c.context_url}
+                        </a>
+                      ) : (
+                        <span className="text-zinc-300">—</span>
+                      )}
                     </td>
                     <td className="py-2 pr-3 text-zinc-400">{c.model}</td>
                     <td className="py-2 text-right text-zinc-300">{formatTokens(c.total_tokens)}</td>

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -189,6 +189,25 @@ export interface AdminDashboardData {
       details: string | null;
     }[];
   };
+  extraction: {
+    worker_enabled: boolean;
+    queue: { never_extracted: number; changed_pending: number; total: number };
+    throughput: {
+      completions: { last_hour: number; last_24h: number; last_7d: number };
+      attempts: { last_hour: number; last_24h: number; last_7d: number };
+    };
+    eta_days: number | null;
+    last_call_at: string | null;
+    last_extracted_at: string | null;
+    tokens_last_24h: number;
+    daily: { date: string; count: number }[];
+    recent_calls: {
+      called_at: string;
+      context_url: string | null;
+      model: string;
+      total_tokens: number;
+    }[];
+  };
 }
 
 async function fetchJsonWithAuth<T>(url: string, init?: RequestInit): Promise<T> {

--- a/database/admin.py
+++ b/database/admin.py
@@ -276,6 +276,104 @@ def _get_activity_stats() -> dict:
     }
 
 
+def _get_extraction_stats() -> dict:
+    """Extraction worker surveillance: queue, throughput, ETA, liveness."""
+    import scheduler
+
+    def _i(row, key) -> int:
+        return int(row[key] or 0) if row else 0
+
+    # Same predicate as the worker's get_urls_needing_extraction(), split by reason.
+    queue = fetch_one(
+        """SELECT
+               SUM(hc.extracted_hash IS NULL) AS never_extracted,
+               SUM(hc.extracted_hash IS NOT NULL
+                   AND hc.extracted_hash != hc.content_hash) AS changed_pending
+           FROM html_content hc
+           JOIN researcher_urls ru ON ru.id = hc.url_id
+           WHERE ru.is_active = TRUE AND hc.content_hash IS NOT NULL"""
+    )
+    never_extracted = _i(queue, "never_extracted")
+    changed_pending = _i(queue, "changed_pending")
+    queue_total = never_extracted + changed_pending
+
+    # Completions = successful mark_extracted timestamps.
+    completions = fetch_one(
+        """SELECT
+               SUM(extracted_at >= NOW() - INTERVAL 1 HOUR) AS last_hour,
+               SUM(extracted_at >= NOW() - INTERVAL 24 HOUR) AS last_24h,
+               SUM(extracted_at >= NOW() - INTERVAL 7 DAY) AS last_7d
+           FROM html_content"""
+    )
+
+    # Attempts = every extraction LLM call (failures included), plus liveness + tokens.
+    attempts = fetch_one(
+        """SELECT
+               SUM(called_at >= NOW() - INTERVAL 1 HOUR) AS last_hour,
+               SUM(called_at >= NOW() - INTERVAL 24 HOUR) AS last_24h,
+               SUM(called_at >= NOW() - INTERVAL 7 DAY) AS last_7d,
+               MAX(called_at) AS last_call_at,
+               COALESCE(SUM(CASE WHEN called_at >= NOW() - INTERVAL 24 HOUR
+                                 THEN total_tokens ELSE 0 END), 0) AS tokens_last_24h
+           FROM llm_usage WHERE call_type = 'publication_extraction'"""
+    )
+
+    last_extracted = fetch_one(
+        "SELECT MAX(extracted_at) AS last_extracted_at FROM html_content"
+    )
+
+    daily = fetch_all(
+        """SELECT DATE(extracted_at) AS date, COUNT(*) AS count
+           FROM html_content
+           WHERE extracted_at >= DATE_SUB(CURDATE(), INTERVAL 14 DAY)
+           GROUP BY DATE(extracted_at) ORDER BY date"""
+    )
+
+    recent_calls = fetch_all(
+        """SELECT called_at, context_url, model, total_tokens
+           FROM llm_usage WHERE call_type = 'publication_extraction'
+           ORDER BY id DESC LIMIT 20"""
+    )
+
+    completions_24h = _i(completions, "last_24h")
+    eta_days = round(queue_total / completions_24h, 1) if completions_24h else None
+
+    return {
+        "worker_enabled": scheduler.EXTRACTION_WORKER_ENABLED,
+        "queue": {
+            "never_extracted": never_extracted,
+            "changed_pending": changed_pending,
+            "total": queue_total,
+        },
+        "throughput": {
+            "completions": {
+                "last_hour": _i(completions, "last_hour"),
+                "last_24h": completions_24h,
+                "last_7d": _i(completions, "last_7d"),
+            },
+            "attempts": {
+                "last_hour": _i(attempts, "last_hour"),
+                "last_24h": _i(attempts, "last_24h"),
+                "last_7d": _i(attempts, "last_7d"),
+            },
+        },
+        "eta_days": eta_days,
+        "last_call_at": _iso_z(attempts["last_call_at"]) if attempts and attempts["last_call_at"] else None,
+        "last_extracted_at": _iso_z(last_extracted["last_extracted_at"]) if last_extracted and last_extracted["last_extracted_at"] else None,
+        "tokens_last_24h": _i(attempts, "tokens_last_24h"),
+        "daily": [{"date": str(r["date"]), "count": int(r["count"])} for r in daily],
+        "recent_calls": [
+            {
+                "called_at": _iso_z(r["called_at"]),
+                "context_url": r["context_url"],
+                "model": r["model"],
+                "total_tokens": int(r["total_tokens"] or 0),
+            }
+            for r in recent_calls
+        ],
+    }
+
+
 def get_admin_dashboard_stats() -> dict:
     """Aggregate all dashboard metrics into a single response dict."""
     return {
@@ -285,4 +383,5 @@ def get_admin_dashboard_stats() -> dict:
         "costs": _get_cost_stats(),
         "scrapes": _get_scrape_stats(),
         "activity": _get_activity_stats(),
+        "extraction": _get_extraction_stats(),
     }

--- a/docs/superpowers/specs/2026-06-10-extraction-admin-tab-design.md
+++ b/docs/superpowers/specs/2026-06-10-extraction-admin-tab-design.md
@@ -1,0 +1,67 @@
+# Extraction Progress Admin Tab
+
+**Date:** 2026-06-10
+**Status:** Approved
+
+## Problem
+
+The continuous extraction worker (PR #139/#140) is draining a ~11k-page backlog in prod, but the only way to surveil it is SSH + log grepping + manual SQL. Worker LLM calls log with `scrape_log_id=NULL`, so the existing Scrapes tab shows nothing about it.
+
+## Decision
+
+Add an **"Extraction" tab** to the existing admin dashboard, fed by a new `extraction` section in the existing `/api/admin/dashboard` aggregate response. No new endpoint, no schema changes — all metrics derive from `html_content` and `llm_usage`. The dashboard's SWR hook gains a 60s `refreshInterval` so the page self-updates while watching.
+
+## Backend: `_get_extraction_stats()` in `database/admin.py`
+
+Added to `get_admin_dashboard_stats()` as `"extraction"`. Response shape:
+
+```json
+{
+  "worker_enabled": true,
+  "queue": {"never_extracted": 6705, "changed_pending": 4213, "total": 10918},
+  "throughput": {
+    "completions": {"last_hour": 38, "last_24h": 950, "last_7d": 950},
+    "attempts":    {"last_hour": 41, "last_24h": 1010, "last_7d": 1010}
+  },
+  "eta_days": 11.5,
+  "last_call_at": "2026-06-10T08:11:02Z",
+  "last_extracted_at": "2026-06-10T08:09:14Z",
+  "tokens_last_24h": 412345,
+  "daily": [{"date": "2026-06-10", "count": 950}, ...],
+  "recent_calls": [{"called_at": "...", "context_url": "...", "model": "gemma-4-31b-it", "total_tokens": 4102}, ...]
+}
+```
+
+Definitions:
+- **Queue** uses the same predicate as the worker's `get_urls_needing_extraction()` (active URLs, `content_hash IS NOT NULL`, hash mismatch or never extracted), split by `extracted_hash IS NULL`. The number on the dashboard matches what the worker logs.
+- **Completions** = `html_content.extracted_at` in window (a successful `mark_extracted`). **Attempts** = `llm_usage` rows with `call_type = 'publication_extraction'` in window. Attempts − completions ≈ failures/empty-parse retries, making quota exhaustion visible.
+- **eta_days** = `queue.total / completions.last_24h` (null when the 24h rate is 0). Float, one decimal in UI.
+- **worker_enabled** read from `scheduler.EXTRACTION_WORKER_ENABLED` (same import-in-function pattern as `_get_health_stats`).
+- **daily** = completions per day, last 14 days, from `extracted_at`. Caveat (accepted): `extracted_at` is overwritten on re-extraction, so historic days undercount slightly.
+- **recent_calls** = last 20 `publication_extraction` rows (called_at, context_url, model, total_tokens).
+
+### Liveness semantics (cross-process caveat)
+
+The API request may be served by the gunicorn worker that does NOT own the worker thread, so thread state is unreadable. Liveness is proxied: the UI shows a **stalled** warning when `worker_enabled` is true, `queue.total > 0`, and `last_call_at` is older than 30 minutes (or null). The 30-minute threshold is a frontend constant — the worker's worst-case quiet period while healthy is the 10-minute backoff.
+
+## Frontend
+
+- `app/src/app/admin/tabs/ExtractionTab.tsx`, styled like the existing tabs (stat cards + tables, dark palette):
+  - Status row: worker enabled/disabled badge, stalled warning per the liveness rule, last call / last extraction relative times.
+  - Stat cards: queue total (with never/changed split), completions last 24h, ETA days, tokens last 24h.
+  - Throughput table: 1h / 24h / 7d × completions / attempts.
+  - Daily table: last 14 days (date, count) — same plain-rows style as Costs' 30-day list.
+  - Recent calls table: time, URL (truncated, link), model, tokens.
+- `AdminDashboard.tsx`: add `{ id: "extraction", label: "Extraction" }` to `TABS` + render branch.
+- `lib/api.ts`: extend `AdminDashboardData` with the `extraction` type; add `refreshInterval: 60_000` to the `useAdminDashboard` SWR options.
+
+## Testing
+
+- `tests/test_admin_dashboard.py`: `_get_extraction_stats` returns the documented shape with mocked `fetch_one`/`fetch_all` (match the file's existing mocking pattern); ETA null when 24h completions = 0; queue split sums to total.
+- Frontend jest: `ExtractionTab` renders fixture data (queue numbers, ETA, stalled badge when last_call_at old, recent-calls rows).
+
+## Out of Scope
+
+- No dedicated polling endpoint (60s aggregate refresh is enough at ~1 URL/min).
+- No per-run attribution of worker calls (`scrape_log_id` stays NULL — known follow-up from PR #139 review).
+- No worker control (pause/resume) from the dashboard.

--- a/tests/test_admin_dashboard.py
+++ b/tests/test_admin_dashboard.py
@@ -38,6 +38,15 @@ def test_get_admin_dashboard_stats_returns_all_sections():
         "active_count": 0,
         "deactivated_count": 0,
         "at_risk_count": 0,
+        # extraction section keys
+        "never_extracted": 0,
+        "changed_pending": 0,
+        "last_hour": 0,
+        "last_24h": 0,
+        "last_7d": 0,
+        "last_call_at": None,
+        "tokens_last_24h": 0,
+        "last_extracted_at": None,
     })
 
     with patch("database.admin.fetch_all", mock_fetch_all), \
@@ -85,6 +94,15 @@ def test_get_admin_dashboard_stats_returns_all_sections():
     assert "events_last_30d" in result["activity"]
     assert "recent_events" in result["activity"]
 
+    # Extraction section
+    assert "extraction" in result
+    assert "worker_enabled" in result["extraction"]
+    assert "queue" in result["extraction"]
+    assert "throughput" in result["extraction"]
+    assert "eta_days" in result["extraction"]
+    assert "daily" in result["extraction"]
+    assert "recent_calls" in result["extraction"]
+
 
 def test_admin_dashboard_endpoint_requires_api_key(client):
     """GET /api/admin/dashboard returns 401 without API key."""
@@ -121,3 +139,61 @@ def test_admin_dashboard_endpoint_returns_data(client):
     assert "health" in data
     assert "content" in data
     assert data["content"]["total_papers"] == 10
+
+
+def _extraction_fetch_one(queue=None, completions=None, attempts=None, last_extracted=None):
+    """Build a fetch_one side_effect for _get_extraction_stats's four queries, in call order."""
+    rows = [
+        queue or {"never_extracted": 0, "changed_pending": 0},
+        completions or {"last_hour": 0, "last_24h": 0, "last_7d": 0},
+        attempts or {"last_hour": 0, "last_24h": 0, "last_7d": 0,
+                     "last_call_at": None, "tokens_last_24h": 0},
+        last_extracted or {"last_extracted_at": None},
+    ]
+    return MagicMock(side_effect=rows)
+
+
+def test_extraction_stats_queue_split_and_eta():
+    """Queue split sums to total; ETA = total / completions_24h, 1 decimal."""
+    from database.admin import _get_extraction_stats
+    mock_one = _extraction_fetch_one(
+        queue={"never_extracted": 6000, "changed_pending": 4000},
+        completions={"last_hour": 40, "last_24h": 1000, "last_7d": 5000},
+    )
+    with patch("database.admin.fetch_one", mock_one), \
+         patch("database.admin.fetch_all", MagicMock(return_value=[])):
+        stats = _get_extraction_stats()
+    assert stats["queue"] == {"never_extracted": 6000, "changed_pending": 4000, "total": 10000}
+    assert stats["eta_days"] == 10.0
+    assert stats["throughput"]["completions"]["last_24h"] == 1000
+
+
+def test_extraction_stats_eta_null_when_no_completions():
+    """ETA is None when nothing completed in 24h (avoid div-by-zero)."""
+    from database.admin import _get_extraction_stats
+    mock_one = _extraction_fetch_one(queue={"never_extracted": 5, "changed_pending": 0})
+    with patch("database.admin.fetch_one", mock_one), \
+         patch("database.admin.fetch_all", MagicMock(return_value=[])):
+        stats = _get_extraction_stats()
+    assert stats["eta_days"] is None
+
+
+def test_extraction_stats_recent_calls_and_daily_shapes():
+    """recent_calls and daily map DB rows into the documented shape."""
+    from datetime import datetime, timezone, date
+    from database.admin import _get_extraction_stats
+    mock_one = _extraction_fetch_one()
+    called = datetime(2026, 6, 10, 8, 0, 0, tzinfo=timezone.utc)
+    mock_all = MagicMock(side_effect=[
+        [{"date": date(2026, 6, 10), "count": 950}],                     # daily
+        [{"called_at": called, "context_url": "https://x.com/pubs",
+          "model": "gemma-4-31b-it", "total_tokens": 4102}],             # recent_calls
+    ])
+    with patch("database.admin.fetch_one", mock_one), \
+         patch("database.admin.fetch_all", mock_all):
+        stats = _get_extraction_stats()
+    assert stats["daily"] == [{"date": "2026-06-10", "count": 950}]
+    assert stats["recent_calls"] == [{
+        "called_at": "2026-06-10T08:00:00Z", "context_url": "https://x.com/pubs",
+        "model": "gemma-4-31b-it", "total_tokens": 4102,
+    }]


### PR DESCRIPTION
## Summary
- New **Extraction** tab on `/admin` to surveil the continuous extraction worker (PR #139) while it drains the ~11k-page backlog: queue depth split into never-extracted vs changed (same predicate as the worker's queue, so numbers match the logs), completions vs attempts throughput over 1h/24h/7d (the gap exposes quota failures), ETA-to-drain, tokens (24h), a 14-day daily trend, and the last 20 LLM calls (linked to source pages).
- **Liveness badge**: shows "possibly stalled" when the worker is enabled, the queue is non-empty, and no LLM call has landed in 30+ minutes (worst healthy quiet period is the 10-min backoff). Cross-process caveat documented in the spec — liveness is proxied via call recency since the API request may hit the gunicorn worker that doesn't own the thread.
- Backend: new `extraction` section in the existing `/api/admin/dashboard` aggregate (`database/admin.py:_get_extraction_stats`) — no new endpoint, no schema changes. Dashboard already auto-refreshes every 60s.

Spec: `docs/superpowers/specs/2026-06-10-extraction-admin-tab-design.md` (included).

## Test Plan
- [x] 874 Python tests pass (3 new: queue split/ETA, ETA-null, response shapes)
- [x] 98 frontend tests pass incl. 6 new ExtractionTab tests (stalled both ways, disabled state, null ETA); tsc clean
- [ ] After merge: Vercel auto-deploys the frontend; run `./scripts/deploy.sh` on Lightsail for the API section, then check the tab live

🤖 Generated with [Claude Code](https://claude.com/claude-code)