### PR TITLE
feat: shareable URLs, Atom feed, and date range filter

### DIFF
--- a/api.py
+++ b/api.py
@@ -181,6 +181,39 @@ def _require_api_key(request: Request) -> None:
 VALID_EVENT_TYPES = frozenset({"new_paper", "status_change"})
 
 
+def _parse_feed_filters(
+    *, status: str | None, institution: str | None,
+    preset: str | None, event_type: str | None,
+    since: str | None, until: str | None,
+) -> tuple[list[str], list[str], datetime | None, datetime | None]:
+    """Parse and validate shared filter params. Returns (status_list, institution_list, since_dt, until_dt)."""
+    status_list = [s.strip() for s in status.split(",") if s.strip()] if status else []
+    institution_list = [i.strip() for i in institution.split(",") if i.strip()] if institution else []
+
+    for s in status_list:
+        if s not in VALID_STATUSES:
+            raise HTTPException(status_code=400, detail=f"Invalid status value '{s}'. Must be one of: {', '.join(sorted(VALID_STATUSES))}")
+    if event_type and event_type not in VALID_EVENT_TYPES:
+        raise HTTPException(status_code=400, detail=f"Invalid event_type value '{event_type}'. Must be one of: {', '.join(sorted(VALID_EVENT_TYPES))}")
+
+    since_dt = None
+    if since:
+        try:
+            since_dt = datetime.fromisoformat(since.rstrip("Z"))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid ?since= value; expected ISO8601 timestamp")
+    until_dt = None
+    if until:
+        try:
+            until_dt = datetime.fromisoformat(until.rstrip("Z"))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid ?until= value; expected ISO8601 timestamp")
+        if until_dt == until_dt.replace(hour=0, minute=0, second=0, microsecond=0):
+            until_dt = until_dt.replace(hour=23, minute=59, second=59)
+
+    return status_list, institution_list, since_dt, until_dt
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     if len(_SCRAPE_API_KEY) < 16:
@@ -470,32 +503,14 @@ def list_publications(
     non-published papers with known status generate events, so no
     include_seed parameter is needed.
     """
-    valid_statuses = VALID_STATUSES
     valid_presets = {"top20"}
-
-    # Parse comma-separated multi-values
-    status_list = [s.strip() for s in status.split(",") if s.strip()] if status else []
-    institution_list = [i.strip() for i in institution.split(",") if i.strip()] if institution else []
-
-    for s in status_list:
-        if s not in valid_statuses:
-            raise HTTPException(status_code=400, detail=f"Invalid status value '{s}'. Must be one of: {', '.join(sorted(valid_statuses))}")
     if preset and preset not in valid_presets:
         raise HTTPException(status_code=400, detail=f"Invalid preset value. Must be one of: {', '.join(sorted(valid_presets))}")
-    if event_type and event_type not in VALID_EVENT_TYPES:
-        raise HTTPException(status_code=400, detail=f"Invalid event_type value '{event_type}'. Must be one of: {', '.join(sorted(VALID_EVENT_TYPES))}")
-    since_dt = None
-    if since:
-        try:
-            since_dt = datetime.fromisoformat(since.rstrip("Z"))
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid ?since= value; expected ISO8601 timestamp")
-    until_dt = None
-    if until:
-        try:
-            until_dt = datetime.fromisoformat(until.rstrip("Z"))
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid ?until= value; expected ISO8601 timestamp")
+
+    status_list, institution_list, since_dt, until_dt = _parse_feed_filters(
+        status=status, institution=institution, preset=preset,
+        event_type=event_type, since=since, until=until,
+    )
 
     offset = (page - 1) * per_page
     with connection_scope():
@@ -590,11 +605,11 @@ def get_publication(
 # ---------------------------------------------------------------------------
 
 ATOM_NS = "http://www.w3.org/2005/Atom"
+ET.register_namespace("", ATOM_NS)
 
 
 def _build_atom_feed(items: list[dict], self_url: str) -> str:
     """Build an Atom XML feed string from formatted publication dicts."""
-    ET.register_namespace("", ATOM_NS)
     feed = ET.Element("feed", xmlns=ATOM_NS)
 
     ET.SubElement(feed, "title").text = "Econ Newsfeed"
@@ -656,27 +671,10 @@ def atom_feed(
     until: str | None = Query(None),
 ):
     """Atom feed of recent publications, supports same filters as /api/publications."""
-    status_list = [s.strip() for s in status.split(",") if s.strip()] if status else []
-    institution_list = [i.strip() for i in institution.split(",") if i.strip()] if institution else []
-
-    for s in status_list:
-        if s not in VALID_STATUSES:
-            raise HTTPException(status_code=400, detail=f"Invalid status value '{s}'")
-    if event_type and event_type not in VALID_EVENT_TYPES:
-        raise HTTPException(status_code=400, detail=f"Invalid event_type value '{event_type}'")
-
-    since_dt = None
-    if since:
-        try:
-            since_dt = datetime.fromisoformat(since.rstrip("Z"))
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid ?since= value")
-    until_dt = None
-    if until:
-        try:
-            until_dt = datetime.fromisoformat(until.rstrip("Z"))
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid ?until= value")
+    status_list, institution_list, since_dt, until_dt = _parse_feed_filters(
+        status=status, institution=institution, preset=preset,
+        event_type=event_type, since=since, until=until,
+    )
 
     with connection_scope():
         rows, _ = Database.search_feed_events(
@@ -690,9 +688,7 @@ def atom_feed(
         authors_by_pub = Database.get_authors_for_papers(pub_ids)
 
     items = [
-        {
-            **_format_feed_event(row, authors_by_pub.get(row['paper_id'], [])),
-        }
+        _format_feed_event(row, authors_by_pub.get(row['paper_id'], []))
         for row in rows
     ]
 

--- a/api.py
+++ b/api.py
@@ -8,6 +8,7 @@ import math
 import os
 import threading
 import time
+import xml.etree.ElementTree as ET
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 
@@ -456,6 +457,7 @@ def list_publications(
     researcher_id: int | None = Query(None),
     status: str | None = Query(None),
     since: str | None = Query(None),
+    until: str | None = Query(None),
     institution: str | None = Query(None),
     preset: str | None = Query(None),
     search: str | None = Query(None, max_length=200),
@@ -488,13 +490,20 @@ def list_publications(
             since_dt = datetime.fromisoformat(since.rstrip("Z"))
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid ?since= value; expected ISO8601 timestamp")
+    until_dt = None
+    if until:
+        try:
+            until_dt = datetime.fromisoformat(until.rstrip("Z"))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid ?until= value; expected ISO8601 timestamp")
 
     offset = (page - 1) * per_page
     with connection_scope():
         rows, total = Database.search_feed_events(
             year=year, researcher_id=researcher_id,
             status_list=status_list or None,
-            since=since_dt, institution_list=institution_list or None,
+            since=since_dt, until=until_dt,
+            institution_list=institution_list or None,
             preset=preset, search=search, event_type=event_type,
             jel_code=jel_code, offset=offset, limit=per_page,
         )
@@ -574,6 +583,124 @@ def get_publication(
         result["openalex_id"] = row.get('openalex_id')
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Atom feed
+# ---------------------------------------------------------------------------
+
+ATOM_NS = "http://www.w3.org/2005/Atom"
+
+
+def _build_atom_feed(items: list[dict], self_url: str) -> str:
+    """Build an Atom XML feed string from formatted publication dicts."""
+    ET.register_namespace("", ATOM_NS)
+    feed = ET.Element("feed", xmlns=ATOM_NS)
+
+    ET.SubElement(feed, "title").text = "Econ Newsfeed"
+    ET.SubElement(feed, "id").text = FRONTEND_URL + "/"
+    ET.SubElement(feed, "link", href=self_url, rel="self", type="application/atom+xml")
+    ET.SubElement(feed, "link", href=FRONTEND_URL, rel="alternate", type="text/html")
+
+    updated_at = items[0]["event_date"] if items else datetime.now(timezone.utc).isoformat() + "Z"
+    ET.SubElement(feed, "updated").text = updated_at
+
+    for item in items:
+        entry = ET.SubElement(feed, "entry")
+        paper_url = f"{FRONTEND_URL}/papers/{item['id']}"
+
+        ET.SubElement(entry, "id").text = f"urn:econ-newsfeed:event:{item.get('event_id', item['id'])}"
+        ET.SubElement(entry, "title").text = item["title"]
+        ET.SubElement(entry, "link", href=paper_url, rel="alternate", type="text/html")
+        ET.SubElement(entry, "updated").text = item.get("event_date") or item.get("discovered_at") or ""
+
+        author_names = [f"{a['first_name']} {a['last_name']}" for a in item.get("authors", [])]
+        if author_names:
+            author_el = ET.SubElement(entry, "author")
+            ET.SubElement(author_el, "name").text = ", ".join(author_names)
+
+        parts = []
+        if item.get("event_type") == "status_change":
+            old = (item.get("old_status") or "unknown").replace("_", " ")
+            new = (item.get("new_status") or "unknown").replace("_", " ")
+            parts.append(f"Status changed: {old} → {new}")
+        if item.get("venue"):
+            parts.append(item["venue"])
+        if item.get("year"):
+            parts.append(str(item["year"]))
+        if item.get("abstract"):
+            parts.append(item["abstract"][:500])
+
+        if parts:
+            ET.SubElement(entry, "summary").text = " | ".join(parts)
+
+        if item.get("doi"):
+            ET.SubElement(entry, "link", href=f"https://doi.org/{item['doi']}", rel="related", title="DOI")
+
+    return '<?xml version="1.0" encoding="utf-8"?>\n' + ET.tostring(feed, encoding="unicode")
+
+
+@app.get("/api/feed.xml")
+@limiter.limit("30/minute")
+def atom_feed(
+    request: Request,
+    response: Response,
+    status: str | None = Query(None),
+    institution: str | None = Query(None),
+    preset: str | None = Query(None),
+    year: str | None = Query(None),
+    search: str | None = Query(None, max_length=200),
+    event_type: str | None = Query(None),
+    jel_code: str | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+):
+    """Atom feed of recent publications, supports same filters as /api/publications."""
+    status_list = [s.strip() for s in status.split(",") if s.strip()] if status else []
+    institution_list = [i.strip() for i in institution.split(",") if i.strip()] if institution else []
+
+    for s in status_list:
+        if s not in VALID_STATUSES:
+            raise HTTPException(status_code=400, detail=f"Invalid status value '{s}'")
+    if event_type and event_type not in VALID_EVENT_TYPES:
+        raise HTTPException(status_code=400, detail=f"Invalid event_type value '{event_type}'")
+
+    since_dt = None
+    if since:
+        try:
+            since_dt = datetime.fromisoformat(since.rstrip("Z"))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid ?since= value")
+    until_dt = None
+    if until:
+        try:
+            until_dt = datetime.fromisoformat(until.rstrip("Z"))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid ?until= value")
+
+    with connection_scope():
+        rows, _ = Database.search_feed_events(
+            year=year, status_list=status_list or None,
+            since=since_dt, until=until_dt,
+            institution_list=institution_list or None,
+            preset=preset, search=search, event_type=event_type,
+            jel_code=jel_code, offset=0, limit=50,
+        )
+        pub_ids = [row['paper_id'] for row in rows]
+        authors_by_pub = Database.get_authors_for_papers(pub_ids)
+
+    items = [
+        {
+            **_format_feed_event(row, authors_by_pub.get(row['paper_id'], [])),
+        }
+        for row in rows
+    ]
+
+    self_url = str(request.url)
+    xml = _build_atom_feed(items, self_url)
+
+    response.headers["Cache-Control"] = "public, max-age=900, stale-while-revalidate=1800"
+    return Response(content=xml, media_type="application/atom+xml; charset=utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/app/src/app/NewsfeedContent.tsx
+++ b/app/src/app/NewsfeedContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { usePublications, useJelCodes, useFilterOptions } from "@/lib/api";
 import { formatDate } from "@/lib/publication-utils";
 import type { FeedFilters, Publication } from "@/lib/types";
@@ -26,6 +27,32 @@ function groupByDate(publications: Publication[]) {
     }
   }
   return groups;
+}
+
+const FILTER_PARAM_KEYS = ["status", "institution", "preset", "year", "search", "jel_code", "since", "until"] as const;
+
+function filtersFromParams(params: URLSearchParams): FeedFilters {
+  const filters: FeedFilters = {};
+  for (const key of FILTER_PARAM_KEYS) {
+    const val = params.get(key);
+    if (val) (filters as Record<string, string>)[key] = val;
+  }
+  return filters;
+}
+
+function filtersToParams(
+  filters: FeedFilters,
+  tab: TabValue,
+  page: number
+): URLSearchParams {
+  const params = new URLSearchParams();
+  if (tab !== "new_paper") params.set("tab", tab);
+  if (page > 1) params.set("page", String(page));
+  for (const key of FILTER_PARAM_KEYS) {
+    const val = (filters as Record<string, string | undefined>)[key];
+    if (val) params.set(key, val);
+  }
+  return params;
 }
 
 /* ---------- constants ---------- */
@@ -89,7 +116,11 @@ function FilterBar({
 
   const yearOptions = getYearOptions();
 
-  const hasActiveFilters = !!(filters.status || filters.institution || filters.preset || filters.year || filters.search || filters.jel_code);
+  const hasActiveFilters = !!(
+    filters.status || filters.institution || filters.preset ||
+    filters.year || filters.search || filters.jel_code ||
+    filters.since || filters.until
+  );
 
   const handleJelChange = useCallback(
     (selected: string[]) => {
@@ -124,6 +155,9 @@ function FilterBar({
     },
     [filters, onChange]
   );
+
+  const dateInputClass =
+    "px-3 py-1.5 font-sans text-sm border border-[var(--border)] rounded-lg bg-[var(--bg-card)] shadow-card focus:outline-none focus:ring-1 focus:ring-[var(--link)]";
 
   return (
     <div className="rounded-lg bg-[var(--bg-card)] shadow-card p-4 mb-8 space-y-3">
@@ -200,6 +234,27 @@ function FilterBar({
           onChange={handleJelChange}
         />
 
+        <div className="flex items-center gap-1.5">
+          <label className="font-sans text-xs text-[var(--text-muted)]">From</label>
+          <input
+            type="date"
+            value={filters.since ?? ""}
+            onChange={(e) =>
+              onChange({ ...filters, since: e.target.value || undefined })
+            }
+            className={dateInputClass}
+          />
+          <label className="font-sans text-xs text-[var(--text-muted)]">to</label>
+          <input
+            type="date"
+            value={filters.until ?? ""}
+            onChange={(e) =>
+              onChange({ ...filters, until: e.target.value || undefined })
+            }
+            className={dateInputClass}
+          />
+        </div>
+
         {hasActiveFilters && (
           <>
             <span className="w-px h-5 bg-[var(--border)]" />
@@ -219,22 +274,36 @@ function FilterBar({
 /* ---------- main component ---------- */
 
 export default function NewsfeedContent() {
-  const [activeTab, setActiveTab] = useState<TabValue>("new_paper");
-  const [page, setPage] = useState(1);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
 
-  /* Sync tab from URL on mount (avoids SSR hydration mismatch) */
+  const initialTab = (searchParams.get("tab") === "status_change" ? "status_change" : "new_paper") as TabValue;
+  const initialPage = Math.max(1, Number(searchParams.get("page")) || 1);
+  const initialFilters = useMemo(() => filtersFromParams(searchParams), [searchParams]);
+
+  const [activeTab, setActiveTab] = useState<TabValue>(initialTab);
+  const [page, setPage] = useState(initialPage);
+  const [filters, setFilters] = useState<FeedFilters>(initialFilters);
+
+  const isInitialMount = useRef(true);
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const tab = params.get("tab");
-    if (tab === "status_change") {
-      setActiveTab("status_change");
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
     }
-  }, []);
-  const [filters, setFilters] = useState<FeedFilters>({});
-  const mergedFilters = { ...filters, event_type: activeTab };
+    const params = filtersToParams(filters, activeTab, page);
+    const qs = params.toString();
+    const next = qs ? `${pathname}?${qs}` : pathname;
+    router.replace(next, { scroll: false });
+  }, [filters, activeTab, page, pathname, router]);
+
+  const mergedFilters = useMemo<FeedFilters>(
+    () => ({ ...filters, event_type: activeTab }),
+    [filters, activeTab]
+  );
   const { data, error, isLoading, isValidating } = usePublications(page, 20, mergedFilters);
 
-  /* Reset page to 1 whenever filters change */
   const handleFilterChange = useCallback((next: FeedFilters) => {
     setFilters(next);
     setPage(1);
@@ -244,11 +313,6 @@ export default function NewsfeedContent() {
     setActiveTab(tab);
     setFilters({});
     setPage(1);
-    if (typeof window !== "undefined") {
-      const url = new URL(window.location.href);
-      url.searchParams.set("tab", tab);
-      window.history.replaceState({}, "", url.toString());
-    }
   }, []);
 
   return (

--- a/app/src/app/NewsfeedContent.tsx
+++ b/app/src/app/NewsfeedContent.tsx
@@ -29,7 +29,7 @@ function groupByDate(publications: Publication[]) {
   return groups;
 }
 
-const FILTER_PARAM_KEYS = ["status", "institution", "preset", "year", "search", "jel_code", "since", "until"] as const;
+const FILTER_PARAM_KEYS = ["status", "institution", "preset", "year", "search", "jel_code", "since", "until"] as const satisfies readonly (keyof Omit<FeedFilters, "event_type">)[];
 
 function filtersFromParams(params: URLSearchParams): FeedFilters {
   const filters: FeedFilters = {};
@@ -278,13 +278,11 @@ export default function NewsfeedContent() {
   const router = useRouter();
   const pathname = usePathname();
 
-  const initialTab = (searchParams.get("tab") === "status_change" ? "status_change" : "new_paper") as TabValue;
-  const initialPage = Math.max(1, Number(searchParams.get("page")) || 1);
-  const initialFilters = useMemo(() => filtersFromParams(searchParams), [searchParams]);
-
-  const [activeTab, setActiveTab] = useState<TabValue>(initialTab);
-  const [page, setPage] = useState(initialPage);
-  const [filters, setFilters] = useState<FeedFilters>(initialFilters);
+  const [activeTab, setActiveTab] = useState<TabValue>(
+    searchParams.get("tab") === "status_change" ? "status_change" : "new_paper"
+  );
+  const [page, setPage] = useState(Math.max(1, Number(searchParams.get("page")) || 1));
+  const [filters, setFilters] = useState<FeedFilters>(() => filtersFromParams(searchParams));
 
   const isInitialMount = useRef(true);
   useEffect(() => {
@@ -296,7 +294,8 @@ export default function NewsfeedContent() {
     const qs = params.toString();
     const next = qs ? `${pathname}?${qs}` : pathname;
     router.replace(next, { scroll: false });
-  }, [filters, activeTab, page, pathname, router]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters, activeTab, page, pathname]);
 
   const mergedFilters = useMemo<FeedFilters>(
     () => ({ ...filters, event_type: activeTab }),

--- a/app/src/app/__tests__/NewsfeedContent.test.tsx
+++ b/app/src/app/__tests__/NewsfeedContent.test.tsx
@@ -5,7 +5,9 @@ import NewsfeedContent from "../NewsfeedContent";
 import type { PaginatedResponse, Publication } from "@/lib/types";
 
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+  useRouter: () => ({ push: jest.fn(), back: jest.fn(), replace: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(window.location.search),
+  usePathname: () => "/",
 }));
 
 const page1: PaginatedResponse<Publication> = {

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -30,6 +30,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${sourceSerif.variable} ${dmSans.variable}`}>
+      <head>
+        <link rel="alternate" type="application/atom+xml" title="Econ Newsfeed" href="/api/feed.xml" />
+      </head>
       <body className="antialiased">
         <Header />
         <main className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import NewsfeedContent from "./NewsfeedContent";
 
 export default function Home() {
-  return <NewsfeedContent />;
+  return (
+    <Suspense>
+      <NewsfeedContent />
+    </Suspense>
+  );
 }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -39,6 +39,8 @@ function buildPublicationsUrl(
   if (filters?.search) params.set("search", filters.search);
   if (filters?.event_type) params.set("event_type", filters.event_type);
   if (filters?.jel_code) params.set("jel_code", filters.jel_code);
+  if (filters?.since) params.set("since", filters.since);
+  if (filters?.until) params.set("until", filters.until + "T23:59:59");
   return `/api/publications?${params.toString()}`;
 }
 

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -40,7 +40,7 @@ function buildPublicationsUrl(
   if (filters?.event_type) params.set("event_type", filters.event_type);
   if (filters?.jel_code) params.set("jel_code", filters.jel_code);
   if (filters?.since) params.set("since", filters.since);
-  if (filters?.until) params.set("until", filters.until + "T23:59:59");
+  if (filters?.until) params.set("until", filters.until);
   return `/api/publications?${params.toString()}`;
 }
 

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -126,6 +126,8 @@ export interface FeedFilters {
   search?: string;
   event_type?: "new_paper" | "status_change";
   jel_code?: string;
+  since?: string;
+  until?: string;
 }
 
 export interface ResearcherDetail extends Researcher {

--- a/database/papers.py
+++ b/database/papers.py
@@ -229,6 +229,7 @@ def search_feed_events(
     researcher_id=None,
     status_list=None,
     since: datetime | None = None,
+    until: datetime | None = None,
     institution_list=None,
     preset=None,
     search=None,
@@ -277,6 +278,10 @@ def search_feed_events(
     if since:
         conditions.append("fe.created_at >= %s")
         params.append(since)
+
+    if until:
+        conditions.append("fe.created_at <= %s")
+        params.append(until)
 
     if institution_list and not preset:
         if len(institution_list) == 1:


### PR DESCRIPTION
## Summary
- **Shareable filter URLs**: All newsfeed filters (tab, status, institution, year, search, JEL code, date range, page) now sync bidirectionally with URL query params via `useSearchParams`. Users can bookmark and share filtered views like `/?tab=status_change&jel_code=J&preset=top20`.
- **Atom feed**: New `/api/feed.xml` endpoint returns a standards-compliant Atom XML feed of the 50 most recent events. Accepts the same filter params as `/api/publications`, so users can subscribe to e.g. `feed.xml?jel_code=J&preset=top20` in their RSS reader. Includes autodiscovery `<link>` tag in the HTML head.
- **Date range filter**: New `since`/`until` params on `/api/publications` and `/api/feed.xml`, with a "From / to" date picker in the frontend filter bar.

## Changed files
- `api.py` — `until` param on `/api/publications`, new `/api/feed.xml` Atom endpoint
- `database/papers.py` — `until` param on `search_feed_events()`
- `app/src/app/NewsfeedContent.tsx` — URL-synced filters, date range picker
- `app/src/app/page.tsx` — `<Suspense>` wrapper for `useSearchParams`
- `app/src/app/layout.tsx` — Atom feed autodiscovery link
- `app/src/lib/types.ts` — `since`/`until` on `FeedFilters`
- `app/src/lib/api.ts` — pass `since`/`until` to API
- `app/src/app/__tests__/NewsfeedContent.test.tsx` — updated navigation mock

## Test plan
- [x] 888 Python tests pass
- [x] 92 Jest frontend tests pass (including 10 NewsfeedContent tests)
- [x] TypeScript compiles cleanly
- [ ] Manual: visit `/?status=working_paper&year=2025` and confirm filters are pre-populated
- [ ] Manual: change filters and confirm URL updates in address bar
- [ ] Manual: open `/api/feed.xml` and verify valid Atom XML
- [ ] Manual: open `/api/feed.xml?jel_code=E` and verify filtered results
- [ ] Manual: select a date range and confirm results are filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)