### PR TITLE
fix: base extraction ETA on last-hour rate

### DIFF
--- a/database/admin.py
+++ b/database/admin.py
@@ -336,7 +336,10 @@ def _get_extraction_stats() -> dict:
     )
 
     completions_24h = _i(completions, "last_24h")
-    eta_days = round(queue_total / completions_24h, 1) if completions_24h else None
+    # ETA from the last hour's rate (×24): reflects current throughput quickly
+    # instead of being dragged down by deploy gaps in a trailing 24h window.
+    completions_hour = _i(completions, "last_hour")
+    eta_days = round(queue_total / (completions_hour * 24), 1) if completions_hour else None
 
     return {
         "worker_enabled": scheduler.EXTRACTION_WORKER_ENABLED,

--- a/docs/superpowers/specs/2026-06-10-extraction-admin-tab-design.md
+++ b/docs/superpowers/specs/2026-06-10-extraction-admin-tab-design.md
@@ -35,7 +35,7 @@ Added to `get_admin_dashboard_stats()` as `"extraction"`. Response shape:
 Definitions:
 - **Queue** uses the same predicate as the worker's `get_urls_needing_extraction()` (active URLs, `content_hash IS NOT NULL`, hash mismatch or never extracted), split by `extracted_hash IS NULL`. The number on the dashboard matches what the worker logs.
 - **Completions** = `html_content.extracted_at` in window (a successful `mark_extracted`). **Attempts** = `llm_usage` rows with `call_type = 'publication_extraction'` in window. Attempts − completions ≈ failures/empty-parse retries, making quota exhaustion visible.
-- **eta_days** = `queue.total / completions.last_24h` (null when the 24h rate is 0). Float, one decimal in UI.
+- **eta_days** = `queue.total / (completions.last_hour × 24)` (null when nothing completed in the last hour). The hourly basis reflects current throughput quickly instead of being dragged down by deploy gaps in a trailing 24h window. Float, one decimal in UI.
 - **worker_enabled** read from `scheduler.EXTRACTION_WORKER_ENABLED` (same import-in-function pattern as `_get_health_stats`).
 - **daily** = completions per day, last 14 days, from `extracted_at`. Caveat (accepted): `extracted_at` is overwritten on re-extraction, so historic days undercount slightly.
 - **recent_calls** = last 20 `publication_extraction` rows (called_at, context_url, model, total_tokens).

--- a/tests/test_admin_dashboard.py
+++ b/tests/test_admin_dashboard.py
@@ -154,7 +154,7 @@ def _extraction_fetch_one(queue=None, completions=None, attempts=None, last_extr
 
 
 def test_extraction_stats_queue_split_and_eta():
-    """Queue split sums to total; ETA = total / completions_24h, 1 decimal."""
+    """Queue split sums to total; ETA = total / (last_hour rate × 24), 1 decimal."""
     from database.admin import _get_extraction_stats
     mock_one = _extraction_fetch_one(
         queue={"never_extracted": 6000, "changed_pending": 4000},
@@ -164,12 +164,13 @@ def test_extraction_stats_queue_split_and_eta():
          patch("database.admin.fetch_all", MagicMock(return_value=[])):
         stats = _get_extraction_stats()
     assert stats["queue"] == {"never_extracted": 6000, "changed_pending": 4000, "total": 10000}
-    assert stats["eta_days"] == 10.0
+    # 40/hour → 960/day → 10000/960 = 10.4 days
+    assert stats["eta_days"] == 10.4
     assert stats["throughput"]["completions"]["last_24h"] == 1000
 
 
 def test_extraction_stats_eta_null_when_no_completions():
-    """ETA is None when nothing completed in 24h (avoid div-by-zero)."""
+    """ETA is None when nothing completed in the last hour (avoid div-by-zero)."""
     from database.admin import _get_extraction_stats
     mock_one = _extraction_fetch_one(queue={"never_extracted": 5, "changed_pending": 0})
     with patch("database.admin.fetch_one", mock_one), \


### PR DESCRIPTION
## Summary
- The Extraction tab's ETA divided the queue by completions in the trailing 24h, which understates throughput whenever the worker has been up for less than a day (right after today's deploys it showed ~124 days instead of ~8). Now extrapolates the last hour's completions to a daily rate; null when the last hour had none.
- Spec updated to match.

## Test Plan
- [x] ETA test updated (40/hour → 960/day → 10.4 days for a 10k queue); 874 Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)