### PR TITLE
fix: auto-capitalize paper titles on save

### DIFF
--- a/database/schema.py
+++ b/database/schema.py
@@ -663,22 +663,18 @@ def create_tables() -> None:
 
                     # Capitalize first letter of lowercase paper titles
                     try:
-                        cursor.execute("""
-                            UPDATE papers
+                        _cap_sql = """
+                            UPDATE {table}
                             SET title = CONCAT(UPPER(LEFT(title, 1)), SUBSTRING(title, 2))
                             WHERE title REGEXP '^[a-z]'
-                        """)
-                        rows = cursor.rowcount
-                        if rows:
-                            cursor.execute("""
-                                UPDATE paper_snapshots
-                                SET title = CONCAT(UPPER(LEFT(title, 1)), SUBSTRING(title, 2))
-                                WHERE title REGEXP '^[a-z]'
-                            """)
-                            conn.commit()
-                            logging.info("Migration: capitalized %d lowercase paper titles", rows)
-                        else:
-                            conn.commit()
+                        """
+                        total = 0
+                        for table in ('papers', 'paper_snapshots'):
+                            cursor.execute(_cap_sql.format(table=table))
+                            total += cursor.rowcount
+                        conn.commit()
+                        if total:
+                            logging.info("Migration: capitalized %d lowercase paper titles", total)
                     except Exception as e:
                         logging.warning("Migration: capitalize titles: %s", e)
                 finally:

--- a/database/schema.py
+++ b/database/schema.py
@@ -660,6 +660,27 @@ def create_tables() -> None:
                     except Exception as e:
                         if getattr(e, 'errno', None) != 1061:
                             logging.warning("Migration: researcher_urls.idx_is_active: %s", e)
+
+                    # Capitalize first letter of lowercase paper titles
+                    try:
+                        cursor.execute("""
+                            UPDATE papers
+                            SET title = CONCAT(UPPER(LEFT(title, 1)), SUBSTRING(title, 2))
+                            WHERE title REGEXP '^[a-z]'
+                        """)
+                        rows = cursor.rowcount
+                        if rows:
+                            cursor.execute("""
+                                UPDATE paper_snapshots
+                                SET title = CONCAT(UPPER(LEFT(title, 1)), SUBSTRING(title, 2))
+                                WHERE title REGEXP '^[a-z]'
+                            """)
+                            conn.commit()
+                            logging.info("Migration: capitalized %d lowercase paper titles", rows)
+                        else:
+                            conn.commit()
+                    except Exception as e:
+                        logging.warning("Migration: capitalize titles: %s", e)
                 finally:
                     cursor.execute("SELECT RELEASE_LOCK('econ_migrations')")
                     cursor.fetchone()

--- a/publication.py
+++ b/publication.py
@@ -124,10 +124,13 @@ _TITLE_BRACKET_SUFFIXES = re.compile(
 
 
 def clean_title(title: str) -> str:
-    """Strip metadata annotations that LLMs sometimes leave in paper titles."""
+    """Strip metadata annotations and ensure title starts with uppercase."""
     title = _TITLE_METADATA_SUFFIXES.sub('', title)
     title = _TITLE_BRACKET_SUFFIXES.sub('', title)
-    return title.strip()
+    title = title.strip()
+    if title and title[0].islower():
+        title = title[0].upper() + title[1:]
+    return title
 
 
 def validate_publication(pub: dict) -> bool:

--- a/tests/test_publication_extraction.py
+++ b/tests/test_publication_extraction.py
@@ -64,6 +64,12 @@ class TestCleanTitle:
         ("New Evidence on Trade", "New Evidence on Trade"),
         ("Submitted Bids in Auctions", "Submitted Bids in Auctions"),
         ("On Accepted Norms", "On Accepted Norms"),
+        # Lowercase title capitalization
+        ("a macroeconomic model with financially constrained producers", "A macroeconomic model with financially constrained producers"),
+        ("anatomy of the phillips curve", "Anatomy of the phillips curve"),
+        ("Already Capitalized", "Already Capitalized"),
+        ("123 numerical start", "123 numerical start"),
+        ("\"quoted title start\"", "\"quoted title start\""),
         # Edge cases
         ("  Spaces  -- JMP  ", "Spaces"),
         ("", ""),


### PR DESCRIPTION
## Summary
- Capitalize first letter of paper titles in `clean_title()` — avoids storing lowercase titles from CSS-styled pages
- Backfill migration capitalizes existing lowercase titles in `papers` and `paper_snapshots`
- `title_hash` is unaffected since `normalize_title` lowercases before hashing

Closes #148

## Test plan
- [x] New parametrized tests: lowercase → capitalized, already-capitalized → unchanged, numeric/quoted start → unchanged
- [x] Full test suite passes (879 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)