### PR TITLE
fix: hide zero-publication coauthors from researcher directory

### DIFF
--- a/database/researchers.py
+++ b/database/researchers.py
@@ -599,10 +599,13 @@ def search_researchers(
     conditions: list[str] = []
     params: list = []
 
-    # Base conditions: only validated researchers
+    # Base conditions: only validated researchers with at least one publication
     conditions.append(
         "(r.openalex_author_id IS NOT NULL OR EXISTS "
         "(SELECT 1 FROM researcher_urls ru WHERE ru.researcher_id = r.id))"
+    )
+    conditions.append(
+        "EXISTS (SELECT 1 FROM authorship a WHERE a.researcher_id = r.id)"
     )
 
     # Hide abbreviated/initial-only names

--- a/tests/test_db_researchers.py
+++ b/tests/test_db_researchers.py
@@ -293,6 +293,11 @@ class TestSearchResearchers:
         assert "openalex_author_id IS NOT NULL" in sql
         assert "researcher_urls" in sql
 
+    def test_base_condition_requires_at_least_one_publication(self):
+        (_, _), mock_fetch = self._call()
+        sql, _ = mock_fetch.call_args[0]
+        assert "authorship" in sql
+
     def test_base_condition_char_length_always_present(self):
         (_, _), mock_fetch = self._call()
         sql, _ = mock_fetch.call_args[0]


### PR DESCRIPTION
## Summary
- Add `EXISTS (SELECT 1 FROM authorship ...)` base condition to `search_researchers`
- Coauthor-only researchers (imported via OpenAlex enrichment) are hidden from the browsable directory
- Researcher detail pages (`/api/researchers/{id}`) still work — they use `get_researcher_detail` which is unaffected

Closes #147

## Test plan
- [x] New test: `test_base_condition_requires_at_least_one_publication` verifies authorship check in SQL
- [x] Full test suite passes (875 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)