### PR TITLE
fix: block status regressions in feed events

### DIFF
--- a/database/schema.py
+++ b/database/schema.py
@@ -677,6 +677,41 @@ def create_tables() -> None:
                             logging.info("Migration: capitalized %d lowercase paper titles", total)
                     except Exception as e:
                         logging.warning("Migration: capitalize titles: %s", e)
+
+                    # Clean up status regression events and restore papers.status
+                    # to highest-ranked status seen across snapshots
+                    _S = "'working_paper','reject_and_resubmit','revise_and_resubmit','accepted','published'"
+                    try:
+                        cursor.execute(f"""
+                            DELETE FROM feed_events
+                            WHERE event_type = 'status_change'
+                            AND FIELD(new_status, {_S}) < FIELD(old_status, {_S})
+                            AND FIELD(new_status, {_S}) > 0
+                            AND FIELD(old_status, {_S}) > 0
+                        """)
+                        deleted = cursor.rowcount
+                        cursor.execute(f"""
+                            UPDATE papers p
+                            JOIN (
+                                SELECT paper_id,
+                                       ELT(MAX(FIELD(status, {_S})), {_S}) AS best_status
+                                FROM paper_snapshots
+                                WHERE status IS NOT NULL
+                                GROUP BY paper_id
+                            ) best ON best.paper_id = p.id
+                            SET p.status = best.best_status
+                            WHERE FIELD(p.status, {_S}) < FIELD(best.best_status, {_S})
+                        """)
+                        restored = cursor.rowcount
+                        conn.commit()
+                        if deleted or restored:
+                            logging.info(
+                                "Migration: cleaned %d status regression events, "
+                                "restored %d paper statuses to highest rank",
+                                deleted, restored,
+                            )
+                    except Exception as e:
+                        logging.warning("Migration: status regression cleanup: %s", e)
                 finally:
                     cursor.execute("SELECT RELEASE_LOCK('econ_migrations')")
                     cursor.fetchone()

--- a/database/snapshots.py
+++ b/database/snapshots.py
@@ -9,6 +9,22 @@ from datetime import datetime, timezone
 from database.connection import get_connection, fetch_all
 
 
+_STATUS_RANK = {
+    'working_paper': 0,
+    'reject_and_resubmit': 1,
+    'revise_and_resubmit': 2,
+    'accepted': 3,
+    'published': 4,
+}
+
+
+def _is_status_progression(old: str | None, new: str | None) -> bool:
+    """Return True only if new status strictly outranks old status."""
+    if not old or not new or old == new:
+        return False
+    return _STATUS_RANK.get(new, -1) > _STATUS_RANK.get(old, -1)
+
+
 @dataclass
 class PaperSnapshotResult:
     changed: bool
@@ -17,9 +33,7 @@ class PaperSnapshotResult:
 
     @property
     def status_changed(self) -> bool:
-        return (self.old_status is not None
-                and self.new_status is not None
-                and self.old_status != self.new_status)
+        return _is_status_progression(self.old_status, self.new_status)
 
 
 # ── Researcher snapshots ──
@@ -109,6 +123,7 @@ def append_paper_snapshot(paper_id: int, status: str | None, venue: str | None,
 
             old_status = prev['status'] if prev else None
 
+            # Always store raw LLM output in snapshots for audit
             cursor.execute(
                 """INSERT INTO paper_snapshots
                    (paper_id, title, status, venue, abstract, draft_url, draft_url_status, year,
@@ -116,12 +131,15 @@ def append_paper_snapshot(paper_id: int, status: str | None, venue: str | None,
                    VALUES (%s, %s, %s, %s, %s, %s, 'unchecked', %s, %s, %s, %s)""",
                 (paper_id, title, status, venue, abstract, draft_url, year, now, source_url, content_hash),
             )
+
+            # Block status regressions on the denormalized papers table
+            effective_status = status if _is_status_progression(old_status, status) or old_status is None else old_status
             cursor.execute(
                 """UPDATE papers
                    SET status = %s, venue = %s, abstract = %s, draft_url = %s,
                        draft_url_status = 'unchecked', year = %s
                    WHERE id = %s""",
-                (status, venue, abstract, draft_url, year, paper_id),
+                (effective_status, venue, abstract, draft_url, year, paper_id),
             )
 
             conn.commit()

--- a/tests/test_snapshots_integration.py
+++ b/tests/test_snapshots_integration.py
@@ -1,11 +1,13 @@
 """Integration tests for snapshot append operations and feed event creation."""
 from unittest.mock import MagicMock, patch
 
+import pytest
 from database.snapshots import (
     append_paper_snapshot,
     append_researcher_snapshot,
     _compute_paper_content_hash,
     _compute_researcher_content_hash,
+    _is_status_progression,
 )
 
 
@@ -150,6 +152,70 @@ class TestAppendPaperSnapshotFeedEvents:
         assert result.changed is True
         sqls = _sql_statements(mock_cursor)
         assert any("INSERT INTO paper_snapshots" in s for s in sqls)
+
+
+class TestStatusProgression:
+
+    @pytest.mark.parametrize("old,new,expected", [
+        ("working_paper", "accepted", True),
+        ("working_paper", "published", True),
+        ("revise_and_resubmit", "accepted", True),
+        ("accepted", "published", True),
+        ("published", "working_paper", False),
+        ("accepted", "working_paper", False),
+        ("published", "revise_and_resubmit", False),
+        ("accepted", "accepted", False),
+        (None, "working_paper", False),
+        ("working_paper", None, False),
+    ])
+    def test_is_status_progression(self, old, new, expected):
+        assert _is_status_progression(old, new) is expected
+
+    def test_regression_suppresses_status_changed(self):
+        """published → working_paper should not report status_changed."""
+        old_hash = _compute_paper_content_hash("published", "AER", "abs", None, "2024")
+        mock_conn, mock_cursor = _make_mock_conn(
+            prev_row={"content_hash": old_hash, "status": "published"},
+        )
+        with patch("database.snapshots.get_connection", return_value=mock_conn):
+            result = append_paper_snapshot(1, "working_paper", "AER", "abs", None, "2024")
+
+        assert result.changed is True
+        assert result.status_changed is False
+
+    def test_regression_preserves_old_status_in_papers_update(self):
+        """When status regresses, the UPDATE papers should use the old status."""
+        old_hash = _compute_paper_content_hash("published", "AER", "abs", None, "2024")
+        mock_conn, mock_cursor = _make_mock_conn(
+            prev_row={"content_hash": old_hash, "status": "published"},
+        )
+        with patch("database.snapshots.get_connection", return_value=mock_conn):
+            append_paper_snapshot(1, "working_paper", "AER", "new abs", None, "2024")
+
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE papers" in str(c)
+        ]
+        assert len(update_calls) == 1
+        args = update_calls[0][0][1]
+        assert args[0] == "published"
+
+    def test_snapshot_stores_raw_llm_status(self):
+        """The snapshot INSERT should contain the raw LLM status, even for regressions."""
+        old_hash = _compute_paper_content_hash("published", "AER", "abs", None, "2024")
+        mock_conn, mock_cursor = _make_mock_conn(
+            prev_row={"content_hash": old_hash, "status": "published"},
+        )
+        with patch("database.snapshots.get_connection", return_value=mock_conn):
+            append_paper_snapshot(1, "working_paper", "AER", "new abs", None, "2024")
+
+        insert_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "INSERT INTO paper_snapshots" in str(c)
+        ]
+        assert len(insert_calls) == 1
+        args = insert_calls[0][0][1]
+        assert "working_paper" in args
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Define status hierarchy: `working_paper` (0) < `reject_and_resubmit` (1) < `revise_and_resubmit` (2) < `accepted` (3) < `published` (4)
- `papers.status` only updates on forward progressions — regressions keep the old (higher-ranked) status
- `status_change` feed events only emitted for forward progressions
- Raw LLM status always stored in `paper_snapshots` for audit trail
- Backfill migration deletes existing regression events and restores paper statuses to highest rank seen

Closes #145

## Test plan
- [x] Parametrized tests for `_is_status_progression` — all forward/backward/equal/null combinations
- [x] Integration tests: regression suppresses `status_changed`, preserves old status in UPDATE, stores raw LLM status in snapshot
- [x] Full test suite passes (887 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)