### PR TITLE
fix: improve year extraction prompt to reduce NULL years

### DIFF
--- a/publication.py
+++ b/publication.py
@@ -244,7 +244,7 @@ class Publication:
 For each publication, extract:
 - title: the full publication title
 - authors: a list of [first_name, last_name] pairs. Use full first names when available (e.g., "John" not "J."). If only an initial appears, use it as given.
-- year: publication year as a string, or null if unknown
+- year: the year associated with this paper as a 4-digit string. Use the publication year, working paper release year, revision date, or most recent year shown near the paper entry. Only return null if no year appears anywhere near the paper entry.
 - venue: journal or conference name, or null if unknown
 - status: one of "published", "accepted", "revise_and_resubmit", "reject_and_resubmit", "working_paper", or null if unknown
 - draft_url: a URL to a PDF, SSRN, NBER, or working paper version, or null if not available


### PR DESCRIPTION
## Summary
- Tighten the LLM extraction prompt for the `year` field
- Instead of "publication year as a string, or null if unknown", explicitly ask for working paper release year, revision date, or most recent year near the entry
- Only return null if no year appears anywhere near the paper entry
- 65% of `new_paper` events had NULL year — this should significantly reduce that rate as pages are re-extracted

Closes #146

## Test plan
- [x] Existing extraction prompt tests pass (65 tests)
- [x] Pydantic `coerce_year_to_str` validator handles edge cases (e.g., "2024a", "forthcoming 2024")
- Improvement will be visible as pages are re-extracted by the extraction worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)