### PR TITLE
fix: show placeholder for NULL researcher affiliations

### DIFF
--- a/app/src/app/researchers/[id]/ResearcherDetailContent.tsx
+++ b/app/src/app/researchers/[id]/ResearcherDetailContent.tsx
@@ -64,13 +64,17 @@ export default function ResearcherDetailContent({ id, initialData }: { id: numbe
             </a>
           )}
         </div>
-        {(researcher.position || researcher.affiliation) && (
-          <p className="mt-1.5 font-sans text-[var(--text-secondary)]">
-            {researcher.position}
-            {researcher.position && researcher.affiliation && ", "}
-            {researcher.affiliation}
-          </p>
-        )}
+        <p className="mt-1.5 font-sans text-[var(--text-secondary)]">
+          {researcher.position || researcher.affiliation ? (
+            <>
+              {researcher.position}
+              {researcher.position && researcher.affiliation && ", "}
+              {researcher.affiliation}
+            </>
+          ) : (
+            <span className="text-[var(--text-muted)] italic">Affiliation unknown</span>
+          )}
+        </p>
         {researcher.description && (
           <p className="mt-3 font-serif text-sm text-[var(--text-secondary)] leading-relaxed">
             {researcher.description}

--- a/app/src/app/researchers/[id]/ResearcherDetailContent.tsx
+++ b/app/src/app/researchers/[id]/ResearcherDetailContent.tsx
@@ -6,6 +6,7 @@ import PublicationCard from "@/components/PublicationCard";
 import PublicationCardSkeleton from "@/components/PublicationCardSkeleton";
 import ErrorMessage from "@/components/ErrorMessage";
 import EmptyState from "@/components/EmptyState";
+import AffiliationLine from "@/components/AffiliationLine";
 import type { ResearcherDetail } from "@/lib/types";
 
 export default function ResearcherDetailContent({ id, initialData }: { id: number; initialData?: ResearcherDetail }) {
@@ -64,17 +65,11 @@ export default function ResearcherDetailContent({ id, initialData }: { id: numbe
             </a>
           )}
         </div>
-        <p className="mt-1.5 font-sans text-[var(--text-secondary)]">
-          {researcher.position || researcher.affiliation ? (
-            <>
-              {researcher.position}
-              {researcher.position && researcher.affiliation && ", "}
-              {researcher.affiliation}
-            </>
-          ) : (
-            <span className="text-[var(--text-muted)] italic">Affiliation unknown</span>
-          )}
-        </p>
+        <AffiliationLine
+          position={researcher.position}
+          affiliation={researcher.affiliation}
+          className="mt-1.5 font-sans text-[var(--text-secondary)]"
+        />
         {researcher.description && (
           <p className="mt-3 font-serif text-sm text-[var(--text-secondary)] leading-relaxed">
             {researcher.description}

--- a/app/src/app/researchers/__tests__/ResearcherDetailContent.test.tsx
+++ b/app/src/app/researchers/__tests__/ResearcherDetailContent.test.tsx
@@ -101,6 +101,20 @@ describe("ResearcherDetailContent", () => {
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
   });
 
+  it("shows placeholder when affiliation is null", async () => {
+    const noAffiliation = { ...researcher, position: null, affiliation: null };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => noAffiliation,
+    });
+
+    renderWithSWR(<ResearcherDetailContent id={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Affiliation unknown")).toBeInTheDocument();
+    });
+  });
+
   it("shows error state", async () => {
     (global.fetch as jest.Mock).mockRejectedValueOnce(
       new Error("Not found")

--- a/app/src/components/AffiliationLine.tsx
+++ b/app/src/components/AffiliationLine.tsx
@@ -1,0 +1,23 @@
+export default function AffiliationLine({
+  position,
+  affiliation,
+  className,
+}: {
+  position: string | null;
+  affiliation: string | null;
+  className?: string;
+}) {
+  return (
+    <p className={className}>
+      {position || affiliation ? (
+        <>
+          {position}
+          {position && affiliation && ", "}
+          {affiliation}
+        </>
+      ) : (
+        <span className="text-[var(--text-muted)] italic">Affiliation unknown</span>
+      )}
+    </p>
+  );
+}

--- a/app/src/components/ResearcherCard.tsx
+++ b/app/src/components/ResearcherCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import AffiliationLine from "@/components/AffiliationLine";
 import type { Researcher } from "@/lib/types";
 
 export default function ResearcherCard({
@@ -21,17 +22,11 @@ export default function ResearcherCard({
           {researcher.first_name} {researcher.last_name}
         </Link>
       </h3>
-      <p className="mt-1 font-sans text-sm text-[var(--text-secondary)]">
-        {researcher.position || researcher.affiliation ? (
-          <>
-            {researcher.position}
-            {researcher.position && researcher.affiliation && ", "}
-            {researcher.affiliation}
-          </>
-        ) : (
-          <span className="text-[var(--text-muted)] italic">Affiliation unknown</span>
-        )}
-      </p>
+      <AffiliationLine
+        position={researcher.position}
+        affiliation={researcher.affiliation}
+        className="mt-1 font-sans text-sm text-[var(--text-secondary)]"
+      />
       <p className="mt-1.5 font-sans text-sm text-[var(--text-muted)]">
         {researcher.publication_count} publications tracked
       </p>

--- a/app/src/components/ResearcherCard.tsx
+++ b/app/src/components/ResearcherCard.tsx
@@ -21,13 +21,17 @@ export default function ResearcherCard({
           {researcher.first_name} {researcher.last_name}
         </Link>
       </h3>
-      {(researcher.position || researcher.affiliation) && (
-        <p className="mt-1 font-sans text-sm text-[var(--text-secondary)]">
-          {researcher.position}
-          {researcher.position && researcher.affiliation && ", "}
-          {researcher.affiliation}
-        </p>
-      )}
+      <p className="mt-1 font-sans text-sm text-[var(--text-secondary)]">
+        {researcher.position || researcher.affiliation ? (
+          <>
+            {researcher.position}
+            {researcher.position && researcher.affiliation && ", "}
+            {researcher.affiliation}
+          </>
+        ) : (
+          <span className="text-[var(--text-muted)] italic">Affiliation unknown</span>
+        )}
+      </p>
       <p className="mt-1.5 font-sans text-sm text-[var(--text-muted)]">
         {researcher.publication_count} publications tracked
       </p>

--- a/app/src/components/__tests__/ResearcherCard.test.tsx
+++ b/app/src/components/__tests__/ResearcherCard.test.tsx
@@ -37,6 +37,12 @@ describe("ResearcherCard", () => {
     expect(screen.getByText(/23 publications/)).toBeInTheDocument();
   });
 
+  it("shows placeholder when affiliation and position are null", () => {
+    const noAffiliation = { ...researcher, position: null, affiliation: null };
+    render(<ResearcherCard researcher={noAffiliation} />);
+    expect(screen.getByText("Affiliation unknown")).toBeInTheDocument();
+  });
+
   it("links to the researcher detail page", () => {
     render(<ResearcherCard researcher={researcher} />);
     const links = screen.getAllByRole("link");


### PR DESCRIPTION
## Summary
- `ResearcherCard` and `ResearcherDetailContent` now display "Affiliation unknown" in muted italic text when both position and affiliation are null
- Previously the entire line was hidden, making it unclear whether the field was empty or just absent
- No layout shift — the `<p>` tag is always rendered

Closes #150

## Test plan
- [x] New test: ResearcherCard shows placeholder when affiliation and position are null
- [x] New test: ResearcherDetailContent shows placeholder when affiliation is null
- [x] Full frontend test suite passes (100 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)