### PR TITLE
fix: clean up incoherent scrapes tab in admin dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Extraction is owned by the extraction worker (below) — the scrape job only ref
 
 **Paper merge:** `merge_duplicate_papers()` dedupes papers post-run.
 
-**Stale scrape_log cleanup:** On scheduler start, any `scrape_log` entries stuck in `'running'` for >24 hours are automatically marked as `'failed'`.
+**Zombie scrape_log cleanup:** On scheduler start and hourly thereafter, `scrape_log` entries stuck in `'running'` are marked `'failed'` based on the scrape advisory lock: if no connection holds the lock, all running rows older than 5 minutes are zombies; if the lock is held, all but the newest running row are. Deploys that restart the container mid-scrape are swept on the next boot.
 
 **`make fetch`** runs stage 1 only (download HTML). Extraction is handled by the extraction worker (or `make extract` manually) — both use the shared `extraction.extract_one_url()`, which protects feed event integrity via `_title_in_previous_snapshot()` and the `_url_has_baseline()` check.
 

--- a/api.py
+++ b/api.py
@@ -27,7 +27,6 @@ import scheduler
 from scheduler import (
     start_scheduler,
     shutdown_scheduler,
-    create_scrape_log,
     run_scrape_job,
 )
 
@@ -897,18 +896,17 @@ async def trigger_scrape(request: Request):
             detail="A scrape is already running. Wait for it to complete.",
         )
 
-    log_id = create_scrape_log()
-    started_at = datetime.now(timezone.utc)
-
+    # run_scrape_job() creates its own scrape_log entry (and acquires the
+    # advisory lock).  Do NOT create one here — that produces an orphan
+    # "running" row that never gets updated.
     t = threading.Thread(
         target=run_scrape_job, daemon=False, name="manual-scrape"
     )
     t.start()
 
     return {
-        "scrape_id": log_id,
         "status": "running",
-        "started_at": _iso_z(started_at),
+        "started_at": _iso_z(datetime.now(timezone.utc)),
     }
 
 

--- a/app/src/app/admin/tabs/ScrapesTab.tsx
+++ b/app/src/app/admin/tabs/ScrapesTab.tsx
@@ -18,11 +18,14 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-function formatDuration(seconds: number | null): string {
+function formatDuration(seconds: number | null, isRunning?: boolean): string {
   if (seconds == null) return "—";
-  const m = Math.floor(seconds / 60);
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
   const s = seconds % 60;
-  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+  const prefix = isRunning ? "~" : "";
+  if (h > 0) return `${prefix}${h}h ${m}m`;
+  return m > 0 ? `${prefix}${m}m ${s}s` : `${prefix}${s}s`;
 }
 
 function formatDate(iso: string): string {
@@ -64,17 +67,20 @@ export default function ScrapesTab({ data }: Props) {
             </tr>
           </thead>
           <tbody>
-            {recent.map((row, i) => (
-              <tr key={i} className="border-b border-[#2a2d3a] last:border-0">
-                <td className="py-2 text-zinc-300 font-mono text-xs">{formatDate(row.started_at)}</td>
-                <td className="py-2"><StatusBadge status={row.status} /></td>
-                <td className="py-2 text-right text-zinc-300">{row.urls_checked}</td>
-                <td className="py-2 text-right text-zinc-300">{row.urls_changed}</td>
-                <td className="py-2 text-right text-zinc-100 font-medium">{row.pubs_extracted}</td>
-                <td className="py-2 text-right text-zinc-300">{row.tokens_used.toLocaleString()}</td>
-                <td className="py-2 text-right text-zinc-300">{formatDuration(row.duration_seconds)}</td>
-              </tr>
-            ))}
+            {recent.map((row, i) => {
+              const isRunning = row.status === "running";
+              return (
+                <tr key={i} className="border-b border-[#2a2d3a] last:border-0">
+                  <td className="py-2 text-zinc-300 font-mono text-xs">{formatDate(row.started_at)}</td>
+                  <td className="py-2"><StatusBadge status={row.status} /></td>
+                  <td className="py-2 text-right text-zinc-300">{row.urls_checked}</td>
+                  <td className="py-2 text-right text-zinc-300">{row.urls_changed}</td>
+                  <td className="py-2 text-right text-zinc-100 font-medium">{row.pubs_extracted}</td>
+                  <td className="py-2 text-right text-zinc-300">{row.tokens_used.toLocaleString()}</td>
+                  <td className={`py-2 text-right ${isRunning ? "text-blue-400" : "text-zinc-300"}`}>{formatDuration(row.duration_seconds, isRunning)}</td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
         {recent.length === 0 && (

--- a/database/admin.py
+++ b/database/admin.py
@@ -207,6 +207,7 @@ def _get_scrape_stats() -> dict:
                             WHERE scrape_log_id = s.id), 0) AS tokens_used
            FROM scrape_log s ORDER BY id DESC LIMIT 30"""
     )
+    now = datetime.now(timezone.utc)
     recent_list = []
     for r in recent:
         started = r["started_at"]
@@ -214,6 +215,9 @@ def _get_scrape_stats() -> dict:
         duration = None
         if started and finished:
             duration = int((finished - started).total_seconds())
+        elif started and r["status"] == "running":
+            started_aware = started if started.tzinfo else started.replace(tzinfo=timezone.utc)
+            duration = int((now - started_aware).total_seconds())
         recent_list.append({
             "started_at": _iso_z(started),
             "status": r["status"],

--- a/main.py
+++ b/main.py
@@ -17,7 +17,14 @@ def import_data(file_path: str) -> None:
 
 def download_htmls() -> None:
     """Download HTML content for all URLs in the researcher_urls table."""
-    from scheduler import create_scrape_log, update_scrape_log
+    from scheduler import create_scrape_log, update_scrape_log, _acquire_db_lock, _release_db_lock
+
+    # Hold the scrape advisory lock: it prevents collisions with a scheduled
+    # scrape, and the zombie cleanup treats lock-less 'running' rows as dead.
+    lock_conn = _acquire_db_lock()
+    if lock_conn is None:
+        logging.warning("Another scrape is running (advisory lock held) — aborting")
+        return
 
     log_id = create_scrape_log()
     researcher_urls = Researcher.get_all_researcher_urls()
@@ -35,6 +42,8 @@ def download_htmls() -> None:
     except Exception as e:
         logging.error(f"Download failed: {e}")
         update_scrape_log(log_id, "failed", urls_checked, urls_changed, error_message=str(e))
+    finally:
+        _release_db_lock(lock_conn)
 
 
 def classify_jel() -> None:
@@ -321,7 +330,10 @@ def batch_check() -> None:
 
 def extract_only(limit: int | None = None) -> None:
     """Run LLM extraction for URLs with pending content changes (skips fetching)."""
-    from scheduler import create_scrape_log, update_scrape_log, _update_progress
+    from scheduler import (
+        create_scrape_log, update_scrape_log, _update_progress,
+        _acquire_db_lock, _release_db_lock,
+    )
     from extraction import extract_one_url
 
     pending = Database.get_urls_needing_extraction()
@@ -334,6 +346,13 @@ def extract_only(limit: int | None = None) -> None:
         pending = pending[:limit]
     else:
         logging.info("Extracting %d pending URLs", len(pending))
+
+    # Hold the scrape advisory lock: the zombie cleanup treats lock-less
+    # 'running' rows as dead, and a concurrent fetch would race extraction.
+    lock_conn = _acquire_db_lock()
+    if lock_conn is None:
+        logging.warning("Another scrape is running (advisory lock held) — aborting")
+        return
 
     log_id = create_scrape_log()
     pubs_extracted = 0
@@ -375,6 +394,8 @@ def extract_only(limit: int | None = None) -> None:
     except Exception as e:
         logging.error("Extraction failed: %s", e)
         update_scrape_log(log_id, "failed", error_message=str(e))
+    finally:
+        _release_db_lock(lock_conn)
 
 
 def discover_domains() -> None:

--- a/scheduler.py
+++ b/scheduler.py
@@ -132,15 +132,15 @@ def update_scrape_log(log_id: int, status: str, urls_checked: int = 0, urls_chan
     ))
 
 
-_STALE_SCRAPE_HOURS = 24
+_STALE_SCRAPE_HOURS = 3
 
 
 def _cleanup_stale_scrape_logs() -> None:
-    """Mark scrape_log entries stuck in 'running' for >24h as 'failed'."""
+    """Mark scrape_log entries stuck in 'running' for >3h as 'failed'."""
     affected = Database.execute_query(
         """UPDATE scrape_log
            SET finished_at = NOW(), status = 'failed',
-               error_message = 'Stale running entry — cleaned up on scheduler start'
+               error_message = 'Stale running entry — cleaned up automatically'
            WHERE status = 'running'
              AND started_at < DATE_SUB(NOW(), INTERVAL %s HOUR)""",
         (_STALE_SCRAPE_HOURS,),
@@ -486,6 +486,12 @@ def start_scheduler() -> None:
         'interval',
         hours=SCRAPE_INTERVAL_HOURS,
         id='scrape_job',
+    )
+    _scheduler.add_job(
+        _cleanup_stale_scrape_logs,
+        'interval',
+        hours=1,
+        id='stale_scrape_cleanup',
     )
     _scheduler.start()
     logger.info(f"Scheduler started: scraping every {SCRAPE_INTERVAL_HOURS} hours")

--- a/scheduler.py
+++ b/scheduler.py
@@ -132,21 +132,31 @@ def update_scrape_log(log_id: int, status: str, urls_checked: int = 0, urls_chan
     ))
 
 
-_STALE_SCRAPE_HOURS = 3
-
-
 def _cleanup_stale_scrape_logs() -> None:
-    """Mark scrape_log entries stuck in 'running' for >3h as 'failed'."""
+    """Mark zombie 'running' scrape_log entries as 'failed'.
+
+    The scrape advisory lock is the source of truth: if no connection holds
+    it, every 'running' row is a leftover from a killed process (e.g. a
+    deploy restarting the container mid-scrape). While the lock is held, the
+    holder's row is the newest 'running' row — anything older is a zombie.
+    The 5-minute grace window avoids racing a scrape that acquired the lock
+    just after we checked it.
+    """
+    if is_scrape_running():
+        where = """status = 'running'
+             AND id < (SELECT mx FROM (SELECT MAX(id) AS mx FROM scrape_log
+                                       WHERE status = 'running') AS newest)"""
+    else:
+        where = """status = 'running'
+             AND started_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)"""
     affected = Database.execute_query(
-        """UPDATE scrape_log
+        f"""UPDATE scrape_log
            SET finished_at = NOW(), status = 'failed',
-               error_message = 'Stale running entry — cleaned up automatically'
-           WHERE status = 'running'
-             AND started_at < DATE_SUB(NOW(), INTERVAL %s HOUR)""",
-        (_STALE_SCRAPE_HOURS,),
+               error_message = 'Zombie running entry — process died mid-scrape'
+           WHERE {where}"""
     )
     if affected:
-        logger.info("Cleaned up %d stale scrape_log entries", affected)
+        logger.info("Cleaned up %d zombie scrape_log entries", affected)
 
 
 _DRAFT_VALIDATION_BUDGET_SECONDS = 300  # 5-minute time budget

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -205,7 +205,6 @@ class TestFullCycle:
         # 7. Trigger scrape (authenticated)
         with (
             patch("api.scheduler.is_scrape_running", return_value=False),
-            patch("api.create_scrape_log", return_value=1),
             patch("api.threading.Thread"),
         ):
             resp = client.post("/api/scrape", headers=AUTH_HEADERS)

--- a/tests/test_api_scrape.py
+++ b/tests/test_api_scrape.py
@@ -45,7 +45,6 @@ class TestTriggerScrape:
     def test_valid_key_returns_201(self, client):
         with (
             patch("api.scheduler.is_scrape_running", return_value=False),
-            patch("api.create_scrape_log", return_value=15),
             patch("api.threading.Thread") as mock_thread,
         ):
             response = client.post(
@@ -55,7 +54,6 @@ class TestTriggerScrape:
 
         assert response.status_code == 201
         body = response.json()
-        assert body["scrape_id"] == 15
         assert body["status"] == "running"
         assert "started_at" in body
 
@@ -63,7 +61,6 @@ class TestTriggerScrape:
         """Scrape thread must be non-daemon so it completes on shutdown."""
         with (
             patch("api.scheduler.is_scrape_running", return_value=False),
-            patch("api.create_scrape_log", return_value=1),
             patch("api.threading.Thread") as mock_thread_cls,
         ):
             client.post("/api/scrape", headers=AUTH_HEADERS)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -345,10 +345,11 @@ class TestScrapeJobIsFetchOnly:
 # ---------------------------------------------------------------------------
 
 class TestStaleLogCleanup:
-    """Verify stale running scrape_log entries get cleaned up."""
+    """Verify zombie running scrape_log entries get cleaned up."""
 
+    @patch("scheduler.is_scrape_running", return_value=False)
     @patch("scheduler.Database.execute_query")
-    def test_marks_old_running_entries_as_failed(self, mock_exec):
+    def test_lock_free_marks_running_entries_as_failed(self, mock_exec, mock_lock):
         mock_exec.return_value = 2
 
         _cleanup_stale_scrape_logs()
@@ -357,10 +358,23 @@ class TestStaleLogCleanup:
         query = mock_exec.call_args[0][0]
         assert "UPDATE scrape_log" in query
         assert "status = 'failed'" in query
-        assert "INTERVAL %s HOUR" in query
+        assert "INTERVAL 5 MINUTE" in query
 
+    @patch("scheduler.is_scrape_running", return_value=True)
     @patch("scheduler.Database.execute_query")
-    def test_skips_when_none_stale(self, mock_exec):
+    def test_lock_held_spares_newest_running_entry(self, mock_exec, mock_lock):
+        mock_exec.return_value = 1
+
+        _cleanup_stale_scrape_logs()
+
+        mock_exec.assert_called_once()
+        query = mock_exec.call_args[0][0]
+        assert "MAX(id)" in query
+        assert "status = 'failed'" in query
+
+    @patch("scheduler.is_scrape_running", return_value=False)
+    @patch("scheduler.Database.execute_query")
+    def test_skips_when_none_stale(self, mock_exec, mock_lock):
         mock_exec.return_value = 0
 
         _cleanup_stale_scrape_logs()


### PR DESCRIPTION
## Problem

The admin dashboard's Scrapes tab showed incoherent data: ~15 entries from June 10 stuck in "running" status, rapid-fire entries minutes apart, and no duration shown for any of them.

## Root causes & fixes

1. **Orphan "running" rows** — `POST /api/scrape` created a `scrape_log` entry *and then* spawned `run_scrape_job()`, which creates its own entry. The endpoint's row was never updated, so every manual trigger left a zombie stuck in "running" forever. Removed the duplicate creation.

2. **Zombies from deploys, swept too late** — every container restart kills the in-flight scrape (SIGTERM grace is seconds; a scrape runs hours), leaving a "running" row, and `SCRAPE_ON_STARTUP` immediately spawns a new scrape. The old cleanup ran only at scheduler startup with a 24h age threshold. Cleanup now runs at startup **and hourly**, and detects zombies via the **scrape advisory lock** instead of age: if no connection holds the lock, every running row (older than a 5-min grace window) is a zombie; if the lock is held, everything but the newest running row is. Deploy zombies are swept on the very next boot.

3. **Running entries showed no duration** — the backend only computed duration when `finished_at` was set. It now returns elapsed time (`NOW() - started_at`) for running entries, and the frontend renders it with a `~` prefix in blue (e.g. `~4h 32m`) to distinguish it from final durations. Durations over an hour display as `Xh Ym` instead of huge minute counts.

## Testing

- `npx tsc --noEmit` clean; all 100 frontend Jest tests pass
- `tests/test_scheduler.py` cleanup tests rewritten for lock-aware behavior (lock free → sweep all; lock held → spare newest)
- Python suite runs in CI (local worktree lacks Python 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)