### PR TITLE
fix: robust title matching in new_paper suppression + snapshot off-by-one

### DIFF
--- a/database/schema.py
+++ b/database/schema.py
@@ -589,7 +589,9 @@ def create_tables() -> None:
                         conn.commit()
                         logging.info("Migration: feed_events snapshot guard trigger created")
                     except Exception as e:
-                        logging.warning("Migration: feed_events trigger: %s", e)
+                        # Without the trigger the DB-level new_paper guard silently
+                        # does not exist (this hid MySQL error 1419 in prod for months)
+                        logging.error("Migration: feed_events trigger NOT created: %s", e)
 
                     # Add title column to paper_snapshots for rename tracking
                     try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   db:
     image: mysql:8.0.40
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb-buffer-pool-size=512M
+    # log-bin-trust-function-creators: without it, MySQL error 1419 blocks the
+    # feed_events snapshot-guard trigger migration (app user lacks SUPER, binlog on)
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb-buffer-pool-size=512M --log-bin-trust-function-creators=1
     restart: unless-stopped
     mem_limit: 1024m
     cpus: 1.0

--- a/feed_events.py
+++ b/feed_events.py
@@ -5,7 +5,9 @@ Consolidates event logic previously scattered across publication.py
 """
 from database import Database
 from datetime import datetime, timezone
+import html as html_module
 import logging
+import re
 import zlib
 
 
@@ -23,18 +25,40 @@ def _url_has_baseline(cursor, url: str, min_snapshots: int = 2) -> bool:
     return (row[0] if row else 0) >= min_snapshots
 
 
+def _normalize_for_matching(text: str) -> str:
+    """Collapse text to lowercase alphanumeric tokens separated by single spaces."""
+    return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+
+
+def _normalize_html_for_matching(raw_html: str) -> str:
+    """Normalize raw page HTML so title substring matching is robust.
+
+    Handles the three encodings that hide titles from a naive substring check:
+    \\uXXXX JS escapes (Google Sites embeds content in JSON), HTML entities
+    (&amp;, &#39;), and titles split across inline tags (<em>, <b>, ...).
+    """
+    def _decode_unicode_escape(m):
+        try:
+            return chr(int(m.group(1), 16))
+        except ValueError:
+            return m.group(0)
+
+    text = re.sub(r"\\u([0-9a-fA-F]{4})", _decode_unicode_escape, raw_html)
+    text = html_module.unescape(text)
+    text = re.sub(r"<[^>]+>", " ", text)
+    return _normalize_for_matching(text)
+
+
 def _get_previous_snapshot_html(cursor, url: str) -> str | None:
-    """Fetch and decompress the previous HTML snapshot for a URL.
+    """Fetch, decompress, and normalize the previous HTML snapshot for a URL.
 
-    Returns lowercased HTML text, or None if no previous snapshot exists.
-    Designed to be called once per URL (before the publication loop),
-    not once per publication.
+    Returns normalized text (see _normalize_html_for_matching), or None if no
+    previous snapshot exists. Designed to be called once per URL (before the
+    publication loop), not once per publication.
 
-    The query uses OFFSET 1 to skip the most-recent snapshot (the one just
-    fetched in the current run) and return the second-most-recent *distinct*
-    HTML state.  This is a proxy for "what the page looked like when the LLM
-    last ran" — not an exact match, but sufficient because researcher pages
-    rarely revert to a prior state.
+    html_snapshots archives the *old* raw_html each time a fetch overwrites
+    html_content (HTMLFetcher.archive_snapshot), so the most-recent snapshot
+    already is the previous page state — no OFFSET needed.
     """
     cursor.execute(
         """SELECT hs.raw_html_compressed
@@ -42,27 +66,28 @@ def _get_previous_snapshot_html(cursor, url: str) -> str | None:
            JOIN researcher_urls ru ON ru.id = hs.url_id
            WHERE ru.url = %s
            ORDER BY hs.snapshot_at DESC
-           LIMIT 1 OFFSET 1""",
+           LIMIT 1""",
         (url,),
     )
     row = cursor.fetchone()
     if not row or not row[0]:
         return None
     try:
-        return zlib.decompress(row[0]).decode("utf-8", errors="replace").lower()
+        raw = zlib.decompress(row[0]).decode("utf-8", errors="replace")
+        return _normalize_html_for_matching(raw)
     except Exception:
         return None
 
 
-def _title_in_previous_snapshot(title: str, prev_html_lower: str | None) -> bool:
+def _title_in_previous_snapshot(title: str, prev_html_normalized: str | None) -> bool:
     """Return True if the paper title appears in the previous HTML snapshot text.
 
-    If the full cleaned title is found in the pre-fetched HTML, the paper was
-    already on the page and should not generate a new_paper feed event.
+    If the normalized title is found in the pre-fetched, normalized HTML, the
+    paper was already on the page and should not generate a new_paper feed event.
     """
-    if not prev_html_lower:
+    if not prev_html_normalized:
         return False
-    return title.lower() in prev_html_lower
+    return _normalize_for_matching(title) in prev_html_normalized
 
 
 class FeedEventEmitter:
@@ -77,7 +102,7 @@ class FeedEventEmitter:
         with Database.get_connection() as conn:
             cursor = conn.cursor(buffered=True)
             has_baseline = _url_has_baseline(cursor, url)
-            prev_html_lower = _get_previous_snapshot_html(cursor, url)
+            prev_html_normalized = _get_previous_snapshot_html(cursor, url)
             cursor.close()
 
             for r in results:
@@ -86,7 +111,7 @@ class FeedEventEmitter:
                 if not has_baseline:
                     logging.info("Suppressed new_paper event for '%s': source URL lacks baseline snapshots", r.title)
                     continue
-                if _title_in_previous_snapshot(r.title, prev_html_lower):
+                if _title_in_previous_snapshot(r.title, prev_html_normalized):
                     logging.info("Suppressed new_paper event for '%s': title found in previous HTML snapshot", r.title)
                     continue
 

--- a/tests/test_feed_event_validation.py
+++ b/tests/test_feed_event_validation.py
@@ -66,14 +66,14 @@ class TestGetPreviousSnapshotHtml(unittest.TestCase):
         cursor.fetchone.return_value = row
         return cursor
 
-    def test_returns_lowered_html(self):
-        """Returns decompressed, lowercased HTML text."""
+    def test_returns_normalized_html(self):
+        """Returns decompressed HTML normalized for matching (tags stripped, lowercased)."""
         html = "<h2>Some Title</h2>"
         compressed = zlib.compress(html.encode("utf-8"))
         cursor = self._make_cursor((compressed,))
 
         result = _get_previous_snapshot_html(cursor, "https://example.com/")
-        assert result == "<h2>some title</h2>"
+        assert result == "some title"
 
     def test_returns_none_when_no_snapshot(self):
         """No previous snapshot → returns None."""

--- a/tests/test_feed_events_emitter.py
+++ b/tests/test_feed_events_emitter.py
@@ -211,14 +211,3 @@ class TestPreviousSnapshotQuery:
         _get_previous_snapshot_html(cursor, "http://example.com")
         sql = cursor.execute.call_args[0][0]
         assert "OFFSET 1" not in sql
-
-    @patch("feed_events.Database.get_connection")
-    def test_returns_normalized_html(self, mock_get_conn):
-        import zlib
-        from feed_events import _get_previous_snapshot_html
-        cursor = MagicMock()
-        cursor.fetchone.return_value = (
-            zlib.compress(b"<p>Media Literacy &amp; <em>Bias</em></p>"),
-        )
-        result = _get_previous_snapshot_html(cursor, "http://example.com")
-        assert "media literacy bias" in result

--- a/tests/test_feed_events_emitter.py
+++ b/tests/test_feed_events_emitter.py
@@ -150,3 +150,75 @@ class TestEmitTitleChange:
         FeedEventEmitter.emit_title_change(1, "Old Title", "New Title")
         insert_calls = [c for c in cursor.execute.call_args_list if "title_change" in str(c)]
         assert len(insert_calls) == 1
+
+
+class TestTitleMatchingNormalization:
+    """Suppression matching must survive HTML entities, \\uXXXX escapes, and inline tags.
+
+    These are the three failure modes that produced bogus new_paper events in
+    production (titles already on the page but missed by naive substring match).
+    """
+
+    def test_finds_title_despite_html_entity_ampersand(self):
+        from feed_events import _title_in_previous_snapshot, _normalize_html_for_matching
+        html = "<li>Media Literacy &amp; Perceived Media Bias in the US</li>"
+        assert _title_in_previous_snapshot(
+            "Media Literacy & Perceived Media Bias in the US",
+            _normalize_html_for_matching(html),
+        )
+
+    def test_finds_title_despite_unicode_escapes(self):
+        from feed_events import _title_in_previous_snapshot, _normalize_html_for_matching
+        # Google Sites embeds content in JS with \uXXXX escapes
+        html = '{"title":"Should Inequality Factor into Central Banks\\u2019 Decisions?"}'
+        assert _title_in_previous_snapshot(
+            "Should Inequality Factor into Central Banks' Decisions?",
+            _normalize_html_for_matching(html),
+        )
+
+    def test_finds_title_split_across_inline_tags(self):
+        from feed_events import _title_in_previous_snapshot, _normalize_html_for_matching
+        html = "<p>Through a Glass, <em>Darkly</em>: Strategic Information</p>"
+        assert _title_in_previous_snapshot(
+            "Through a Glass, Darkly: Strategic Information",
+            _normalize_html_for_matching(html),
+        )
+
+    def test_does_not_find_absent_title(self):
+        from feed_events import _title_in_previous_snapshot, _normalize_html_for_matching
+        html = "<p>Completely unrelated page content</p>"
+        assert not _title_in_previous_snapshot(
+            "Worldwide Environmental Engel Curves",
+            _normalize_html_for_matching(html),
+        )
+
+    def test_none_html_returns_false(self):
+        from feed_events import _title_in_previous_snapshot
+        assert not _title_in_previous_snapshot("Any Title", None)
+
+
+class TestPreviousSnapshotQuery:
+    """html_snapshots archives the OLD state before each overwrite, so the
+    most-recent snapshot already IS the previous page state. The lookup must
+    not skip it with OFFSET 1."""
+
+    @patch("feed_events.Database.get_connection")
+    def test_uses_most_recent_snapshot_not_offset_1(self, mock_get_conn):
+        import zlib
+        from feed_events import _get_previous_snapshot_html
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (zlib.compress(b"<p>Prev State</p>"),)
+        _get_previous_snapshot_html(cursor, "http://example.com")
+        sql = cursor.execute.call_args[0][0]
+        assert "OFFSET 1" not in sql
+
+    @patch("feed_events.Database.get_connection")
+    def test_returns_normalized_html(self, mock_get_conn):
+        import zlib
+        from feed_events import _get_previous_snapshot_html
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (
+            zlib.compress(b"<p>Media Literacy &amp; <em>Bias</em></p>"),
+        )
+        result = _get_previous_snapshot_html(cursor, "http://example.com")
+        assert "media literacy bias" in result


### PR DESCRIPTION
## Summary

Spot-checking production feed events against raw HTML snapshots found **6 of 24 recent `new_paper` events were bogus** — the paper title had been on the page for weeks (in some cases since March). This PR fixes the three bugs that let them through:

- **Naive substring matching in `_title_in_previous_snapshot`** missed titles that were on the page but hidden by encoding: HTML entities (`&amp;`, `&#39;`), `\uXXXX` JS escapes (Google Sites embeds page content in JSON), and titles split across inline tags (`<em>`, `<b>`). Both the title and the snapshot HTML are now normalized (unicode-escape decode → entity unescape → tag strip → lowercase alphanumeric collapse) before matching. Each failure mode has a regression test reproducing a real production case.
- **Off-by-one in `_get_previous_snapshot_html`**: `html_snapshots` archives the *old* state before each overwrite (`HTMLFetcher.archive_snapshot`), so the most-recent snapshot already *is* the previous page state. The `OFFSET 1` skipped it and compared against the state two fetches back, weakening suppression further under extraction backlog.
- **DB-level snapshot-guard trigger never existed in production**: the `trg_feed_events_snapshot_guard` migration fails on every startup with MySQL error 1419 (app user lacks SUPER, binlog enabled). Added `--log-bin-trust-function-creators=1` to the MySQL container command so the trigger is created on next deploy.

Verified-bogus events found in the spot check: FE#3193, 3171, 3184, 3185, 3152, 3169 (titles present in prior snapshots), plus FE#3187 (source URL has zero snapshots — baseline guard violation, inserted before today's deploy).

## Test Plan

- [x] `poetry run pytest` — 905 passed (8 new tests: 5 normalization cases, 2 snapshot-query contract, 1 updated to new contract)
- [ ] After deploy: confirm `SHOW TRIGGERS` lists `trg_feed_events_snapshot_guard` (DB container must be recreated: `docker compose up -d db`)
- [ ] Delete the 7 bogus events on prod: `DELETE FROM feed_events WHERE id IN (3193,3171,3184,3185,3152,3169,3187);`

🤖 Generated with [Claude Code](https://claude.com/claude-code)