### PR TITLE
fix: prevent MySQL container memory exhaustion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ services:
     image: mysql:8.0.40
     # log-bin-trust-function-creators: without it, MySQL error 1419 blocks the
     # feed_events snapshot-guard trigger migration (app user lacks SUPER, binlog on)
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb-buffer-pool-size=512M --log-bin-trust-function-creators=1
+    # performance-schema=off: saves ~150-200MB; with it on, total usage creeps
+    # to the 1GiB mem_limit and the container thrashes until healthchecks time out
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb-buffer-pool-size=512M --log-bin-trust-function-creators=1 --performance-schema=off
     restart: unless-stopped
     mem_limit: 1024m
     cpus: 1.0
@@ -19,7 +21,7 @@ services:
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s
-      timeout: 5s
+      timeout: 10s
       retries: 5
       start_period: 30s
 


### PR DESCRIPTION
## Summary
- DB container crept to its 1GiB mem_limit over ~13h (performance_schema + per-connection buffers; buffer pool was already capped at 512M), then thrashed until healthcheck pings took 40s — Docker marked it unhealthy, which blocked tonight's deploy and took the API down
- Disable `performance_schema` (~150-200MB saved, unused for monitoring)
- Bump healthcheck timeout 5s → 10s so transient slowness doesn't cascade into "unhealthy"

## Test plan
- [x] Deploy to prod, verify DB container goes healthy and stays under ~700MB
- [x] Verify `/api/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)