### PR TITLE
Data-quality test suite, prod sync tooling, backup hardening, fetcher backfill fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ make kill                 # Kill processes on ports 8000/8001/3000/3001
 # Database
 make seed                 # Create tables + run migrations (idempotent)
 make reset-db             # Drop and recreate database from scratch
+make sync-prod            # DESTRUCTIVE: replace local DB with latest prod backup (downloads dump first, then recreates volume)
 
 # Scraping pipeline
 make scrape               # Fetch-only pipeline: download HTML + draft URL validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ make discover-domains     # Scan HTML for untrusted domains with paper-like link
 
 # Testing & validation
 make check                # Full suite: env check → pytest → tsc → jest
+make check-data           # Data-quality invariants against the real DB (tests_data_quality/) — failures are bad rows, not code bugs
 poetry run pytest                        # All Python tests
 poetry run pytest tests/test_api_publications.py  # Single test file
 poetry run pytest -k test_name           # Single test by name

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ check:
 check-data:  ## Data-quality invariant checks against the real DB (.env); fails on bad rows
 	poetry run pytest tests_data_quality -v
 
+sync-prod:  ## DESTRUCTIVE: replace local DB with latest prod backup (scp + fresh volume + migrations)
+	./scripts/sync_prod_db.sh
+
 # Eval
 eval-export:
 	poetry run python eval/export_test_cases.py

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ check:
 	cd app && npx jest
 	@echo "=== All checks passed ==="
 
+check-data:  ## Data-quality invariant checks against the real DB (.env); fails on bad rows
+	poetry run pytest tests_data_quality -v
+
 # Eval
 eval-export:
 	poetry run python eval/export_test_cases.py

--- a/app/src/components/__tests__/AffiliationLine.test.tsx
+++ b/app/src/components/__tests__/AffiliationLine.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for AffiliationLine — catches NULL handling bugs like PR #155.
+ *
+ * PR #155: ResearcherCard showed blank line when both position and
+ * affiliation were null, making it unclear if data was missing or absent.
+ */
+import { render, screen } from "@testing-library/react";
+import AffiliationLine from "../AffiliationLine";
+
+describe("AffiliationLine", () => {
+  it("shows placeholder when both position and affiliation are null", () => {
+    render(<AffiliationLine position={null} affiliation={null} />);
+    expect(screen.getByText("Affiliation unknown")).toBeInTheDocument();
+  });
+
+  it("renders placeholder in italic styling", () => {
+    render(<AffiliationLine position={null} affiliation={null} />);
+    const placeholder = screen.getByText("Affiliation unknown");
+    expect(placeholder.classList.contains("italic")).toBe(true);
+  });
+
+  it("shows only affiliation when position is null", () => {
+    render(<AffiliationLine position={null} affiliation="MIT" />);
+    expect(screen.getByText("MIT")).toBeInTheDocument();
+    expect(screen.queryByText("Affiliation unknown")).not.toBeInTheDocument();
+  });
+
+  it("shows only position when affiliation is null", () => {
+    render(<AffiliationLine position="Professor" affiliation={null} />);
+    expect(screen.getByText("Professor")).toBeInTheDocument();
+    expect(screen.queryByText("Affiliation unknown")).not.toBeInTheDocument();
+  });
+
+  it("shows both with comma separator", () => {
+    const { container } = render(<AffiliationLine position="Professor" affiliation="MIT" />);
+    const p = container.querySelector("p");
+    expect(p?.textContent).toBe("Professor, MIT");
+  });
+
+  it("does not show comma when only one field present", () => {
+    render(<AffiliationLine position="Professor" affiliation={null} />);
+    expect(screen.queryByText(",")).not.toBeInTheDocument();
+  });
+
+  it("does not render undefined or 'null' as text", () => {
+    render(<AffiliationLine position={null} affiliation={null} />);
+    const container = screen.getByText("Affiliation unknown").closest("p");
+    expect(container?.textContent).not.toContain("undefined");
+    expect(container?.textContent).not.toContain("null");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <AffiliationLine position="Prof" affiliation="MIT" className="custom-class" />
+    );
+    expect(container.querySelector(".custom-class")).toBeInTheDocument();
+  });
+});

--- a/app/src/components/__tests__/PublicationCard.edge-cases.test.tsx
+++ b/app/src/components/__tests__/PublicationCard.edge-cases.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Edge-case tests for PublicationCard — null/missing fields must not crash.
+ *
+ * Catches bugs like PR #146 (65% NULL years), #155 (NULL affiliations),
+ * and ensures status_change events with null statuses render safely.
+ */
+import { render, screen } from "@testing-library/react";
+import PublicationCard from "../PublicationCard";
+import type { Publication } from "@/lib/types";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const basePublication: Publication = {
+  id: 1,
+  title: "Test Paper Title",
+  authors: [{ id: 1, first_name: "Jane", last_name: "Doe" }],
+  year: null,
+  venue: null,
+  source_url: null,
+  discovered_at: "2026-01-01T00:00:00Z",
+  status: null,
+  abstract: null,
+  draft_url: null,
+  draft_url_status: "unchecked",
+  draft_available: false,
+  doi: null,
+  coauthors: [],
+  links: [],
+};
+
+describe("PublicationCard with null fields", () => {
+  it("renders without crashing when year is null", () => {
+    render(<PublicationCard publication={{ ...basePublication, year: null }} />);
+    expect(screen.getByText("Test Paper Title")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when venue is null", () => {
+    render(<PublicationCard publication={{ ...basePublication, venue: null }} />);
+    expect(screen.getByText("Test Paper Title")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when both year and venue are null", () => {
+    render(<PublicationCard publication={basePublication} />);
+    expect(screen.getByText("Test Paper Title")).toBeInTheDocument();
+  });
+
+  it("does not render venue/year separator when both are null", () => {
+    const { container } = render(<PublicationCard publication={basePublication} />);
+    expect(container.textContent).not.toContain("·");
+  });
+
+  it("renders venue without year correctly", () => {
+    render(<PublicationCard publication={{ ...basePublication, venue: "AER" }} />);
+    expect(screen.getByText("AER")).toBeInTheDocument();
+  });
+
+  it("renders year without venue correctly", () => {
+    render(<PublicationCard publication={{ ...basePublication, year: "2024" }} />);
+    expect(screen.getByText(/2024/)).toBeInTheDocument();
+  });
+
+  it("renders both venue and year comma-separated", () => {
+    render(<PublicationCard publication={{ ...basePublication, venue: "AER", year: "2024" }} />);
+    expect(screen.getByText("AER, 2024")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when status is null", () => {
+    render(<PublicationCard publication={{ ...basePublication, status: null }} />);
+    expect(screen.getByText("Test Paper Title")).toBeInTheDocument();
+  });
+
+  it("does not render status pill when status is null", () => {
+    const { container } = render(<PublicationCard publication={basePublication} />);
+    expect(screen.queryByText("Working Paper")).not.toBeInTheDocument();
+    expect(screen.queryByText("Published")).not.toBeInTheDocument();
+  });
+
+  it("renders status pill when status is provided", () => {
+    render(<PublicationCard publication={{ ...basePublication, status: "working_paper" }} />);
+    expect(screen.getByText("Working Paper")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when authors array is empty", () => {
+    render(<PublicationCard publication={{ ...basePublication, authors: [] }} />);
+    expect(screen.getByText("Test Paper Title")).toBeInTheDocument();
+  });
+
+  it("does not render DOI link when doi is null", () => {
+    render(<PublicationCard publication={basePublication} />);
+    expect(screen.queryByText("DOI")).not.toBeInTheDocument();
+  });
+
+  it("does not render draft link when draft_available is false", () => {
+    render(<PublicationCard publication={basePublication} />);
+    expect(screen.queryByText("Draft")).not.toBeInTheDocument();
+  });
+
+  it("does not render abstract toggle when abstract is null", () => {
+    render(<PublicationCard publication={basePublication} />);
+    expect(screen.queryByText("Abstract")).not.toBeInTheDocument();
+  });
+
+  it("does not render coauthors section when coauthors is empty", () => {
+    render(<PublicationCard publication={basePublication} />);
+    expect(screen.queryByText(/All authors:/)).not.toBeInTheDocument();
+  });
+
+  it("does not render link pills when links is empty", () => {
+    render(<PublicationCard publication={basePublication} />);
+    expect(screen.queryByText("PDF")).not.toBeInTheDocument();
+    expect(screen.queryByText("SSRN")).not.toBeInTheDocument();
+  });
+});
+
+describe("PublicationCard status change events", () => {
+  it("renders status change banner with valid statuses", () => {
+    render(
+      <PublicationCard
+        publication={{
+          ...basePublication,
+          event_type: "status_change",
+          old_status: "working_paper",
+          new_status: "accepted",
+        }}
+      />
+    );
+    expect(screen.getByText("Status update:")).toBeInTheDocument();
+    expect(screen.getByText("Working Paper")).toBeInTheDocument();
+    expect(screen.getByText("Accepted")).toBeInTheDocument();
+  });
+
+  it("does not render status change banner for new_paper events", () => {
+    render(
+      <PublicationCard
+        publication={{
+          ...basePublication,
+          event_type: "new_paper",
+          status: "working_paper",
+        }}
+      />
+    );
+    expect(screen.queryByText("Status update:")).not.toBeInTheDocument();
+  });
+
+  it("hides status pill during status_change event to avoid duplication", () => {
+    render(
+      <PublicationCard
+        publication={{
+          ...basePublication,
+          event_type: "status_change",
+          old_status: "working_paper",
+          new_status: "accepted",
+          status: "accepted",
+        }}
+      />
+    );
+    const pills = screen.getAllByText("Accepted");
+    expect(pills).toHaveLength(1);
+  });
+});

--- a/html_fetcher.py
+++ b/html_fetcher.py
@@ -583,15 +583,29 @@ class HTMLFetcher:
             logging.info(f"New version of text content saved for URL ID: {url_id}, URL: {url}")
             return True
 
-        # Update timestamp (for cooldown) and backfill raw_html if missing
-        from database import Database
-        Database.execute_query(
-            "UPDATE html_content SET timestamp = %s, raw_html = COALESCE(raw_html, %s) WHERE url_id = %s",
-            (datetime.now(timezone.utc), raw_html, url_id),
-        )
+        HTMLFetcher._touch_unchanged(url_id, raw_html, text_content)
 
         logging.info(f"No text changes detected for URL ID: {url_id}, URL: {url}")
         return False
+
+    @staticmethod
+    def _touch_unchanged(url_id: int, raw_html: str | None, text_content: str) -> None:
+        """Update the cooldown timestamp and backfill missing bodies when the hash is unchanged.
+
+        Rows restored from a metadata-only dump carry content_hash but NULL
+        content; the matching hash means the save path never runs, so without
+        this backfill the body stays missing forever and extraction loops on
+        no_content (4,536 prod rows were stuck this way on 2026-06-11).
+        """
+        from database import Database
+        Database.execute_query(
+            """UPDATE html_content
+               SET timestamp = %s,
+                   raw_html = COALESCE(raw_html, %s),
+                   content = IF(content IS NULL OR content = '', %s, content)
+               WHERE url_id = %s""",
+            (datetime.now(timezone.utc), raw_html, text_content, url_id),
+        )
 
     @staticmethod
     def extract_description(text_content: str, url: str, scrape_log_id=None) -> str | None:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -32,7 +32,21 @@ if [ -z "$DB_CONTAINER" ]; then
     exit 1
 fi
 
-docker exec "$DB_CONTAINER" mysqldump -u root -p"$MYSQL_ROOT_PASSWORD" econ_newsfeed | gzip > "$BACKUP_FILE"
+# Dump to a .partial file and only promote it after verifying the
+# '-- Dump completed' trailer. A mysqldump that dies mid-stream (e.g. the
+# db container under memory pressure on the html blob tables) still leaves
+# a gzip-valid file — without this check a truncated dump silently becomes
+# the "latest backup" (happened on 2026-06-01: the dump lacked researchers
+# and papers entirely).
+docker exec "$DB_CONTAINER" mysqldump -u root -p"$MYSQL_ROOT_PASSWORD" \
+    --single-transaction --quick econ_newsfeed | gzip > "$BACKUP_FILE.partial"
+
+if ! gunzip -c "$BACKUP_FILE.partial" | tail -1 | grep -q '^-- Dump completed'; then
+    rm -f "$BACKUP_FILE.partial"
+    echo "ERROR: dump truncated (no '-- Dump completed' trailer) — backup discarded" >&2
+    exit 1
+fi
+mv "$BACKUP_FILE.partial" "$BACKUP_FILE"
 
 echo "Backup created: $BACKUP_FILE ($(du -h "$BACKUP_FILE" | cut -f1))"
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 # Daily MySQL backup for econ-newsfeed
-# Cron: 0 3 * * * /opt/econ-newsfeed/scripts/backup.sh
+# Cron: 0 3 * * * /opt/econ-newsfeed/scripts/backup.sh >> /backups/backup.log 2>&1
+#
+# The log MUST live somewhere the ubuntu user can write (/backups, not
+# /var/log) — a failing redirect kills the cron job before this script
+# even starts, which silently disabled backups until 2026-06-11.
 #
 # Requires: MYSQL_ROOT_PASSWORD set in environment or sourced from .env
 

--- a/scripts/sync_prod_db.sh
+++ b/scripts/sync_prod_db.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Refresh the local MySQL database from the latest production backup.
+#
+#   make sync-prod          # or: ./scripts/sync_prod_db.sh
+#
+# DESTRUCTIVE to local data: drops the local docker volume and rebuilds it
+# from the newest /backups/econ_newsfeed_*.sql.gz on the Lightsail host.
+# The dump is downloaded and verified BEFORE anything local is touched,
+# so a failed download leaves the local DB exactly as it was.
+#
+# Steps:
+#   1. Find + scp the latest prod backup (fail early, local DB untouched)
+#   2. Stop db service, remove the mysql_data volume (also removes any
+#      stray econ-dq-mysql container holding the volume)
+#   3. Recreate db via docker compose (pinned image, fresh volume)
+#   4. Import as root with a temporary memory bump (large imports OOM at
+#      the compose mem_limit — see CLAUDE.md gotchas)
+#   5. Apply schema migrations from the current checkout (make seed logic)
+#
+# Overrides: LIGHTSAIL_HOST, LIGHTSAIL_KEY, PYTHON_BIN (e.g. a venv python
+# when poetry is not set up in this checkout).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+LIGHTSAIL_HOST="${LIGHTSAIL_HOST:-ubuntu@18.195.185.188}"
+LIGHTSAIL_KEY="${LIGHTSAIL_KEY:-$HOME/.ssh/LightsailDefaultKey-eu-central-1.pem}"
+PYTHON_BIN="${PYTHON_BIN:-poetry run python}"
+# Pin the compose project so the same containers/volume are targeted no
+# matter which checkout (main repo or worktree) this script runs from.
+COMPOSE=(docker compose -p econ-newsfeed)
+WORK_DIR="/tmp/econ-sync"
+DB_NAME="${DB_NAME:-econ_newsfeed}"
+
+if [ ! -f .env ]; then
+    echo "ERROR: .env not found in $PROJECT_DIR (need MYSQL_ROOT_PASSWORD)" >&2
+    exit 1
+fi
+MYSQL_ROOT_PASSWORD="$(grep '^MYSQL_ROOT_PASSWORD=' .env | head -1 | cut -d= -f2-)"
+if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+    echo "ERROR: MYSQL_ROOT_PASSWORD not set in .env" >&2
+    exit 1
+fi
+
+# ── 1. Download latest backup (before touching anything local) ──────────────
+mkdir -p "$WORK_DIR"
+echo "=== Finding latest prod backup on $LIGHTSAIL_HOST ==="
+LATEST=$(ssh -i "$LIGHTSAIL_KEY" -o ConnectTimeout=15 "$LIGHTSAIL_HOST" \
+    'ls -t /backups/econ_newsfeed_*.sql.gz 2>/dev/null | head -1')
+if [ -z "$LATEST" ]; then
+    echo "ERROR: no backups found in /backups on the server" >&2
+    exit 1
+fi
+DUMP="$WORK_DIR/$(basename "$LATEST")"
+echo "Latest: $LATEST"
+if [ -f "$DUMP" ]; then
+    echo "Already downloaded: $DUMP"
+else
+    scp -i "$LIGHTSAIL_KEY" "$LIGHTSAIL_HOST:$LATEST" "$DUMP.partial"
+    mv "$DUMP.partial" "$DUMP"
+fi
+gunzip -t "$DUMP"
+# A gzip-valid file can still be a TRUNCATED dump (mysqldump died mid-stream
+# but gzip closed cleanly — happened with the 2026-06-01 prod backup, which
+# silently lacked researchers/papers). Only a '-- Dump completed' trailer
+# proves mysqldump finished.
+if ! gunzip -c "$DUMP" | tail -1 | grep -q '^-- Dump completed'; then
+    mv "$DUMP" "$DUMP.truncated"
+    echo "ERROR: backup is TRUNCATED — no '-- Dump completed' trailer." >&2
+    echo "The server-side mysqldump died mid-dump. Fix backups on the server" >&2
+    echo "(scripts/backup.sh) and create a fresh one. Local DB left untouched." >&2
+    echo "Truncated file kept at $DUMP.truncated for inspection." >&2
+    exit 1
+fi
+echo "Downloaded and verified: $DUMP ($(du -h "$DUMP" | cut -f1))"
+
+# ── 2. Tear down local DB ────────────────────────────────────────────────────
+echo "=== Recreating local database volume ==="
+if docker ps --format '{{.Names}}' | grep -q '^econ-newsfeed-api'; then
+    "${COMPOSE[@]}" stop api
+fi
+if pgrep -f "uvicorn.*api" >/dev/null 2>&1; then
+    echo "WARNING: a local API process appears to be running (make dev?) — stop it to avoid writes during import"
+fi
+"${COMPOSE[@]}" rm -sf db 2>/dev/null || true
+# A repair container (e.g. econ-dq-mysql) may still hold the volume
+docker ps -aq --filter volume=econ-newsfeed_mysql_data | xargs -r docker rm -f
+docker volume rm -f econ-newsfeed_mysql_data 2>/dev/null || true
+
+# ── 3. Fresh DB under the pinned compose image ──────────────────────────────
+"${COMPOSE[@]}" up -d db
+DB_CONTAINER=$("${COMPOSE[@]}" ps -q db)
+echo -n "Waiting for MySQL to initialize"
+for _ in $(seq 1 90); do
+    if docker exec "$DB_CONTAINER" mysqladmin ping -uroot -p"$MYSQL_ROOT_PASSWORD" --silent 2>/dev/null; then
+        echo " — ready"; break
+    fi
+    echo -n "."; sleep 2
+done
+docker exec "$DB_CONTAINER" mysqladmin ping -uroot -p"$MYSQL_ROOT_PASSWORD" --silent 2>/dev/null \
+    || { echo "ERROR: MySQL did not become ready" >&2; exit 1; }
+
+# ── 4. Import with temporary memory bump ────────────────────────────────────
+echo "=== Importing $(basename "$DUMP") ==="
+docker update --memory 1500m --memory-swap 1500m "$DB_CONTAINER" >/dev/null
+restore_memory() { docker update --memory 1024m --memory-swap 1024m "$DB_CONTAINER" >/dev/null 2>&1 || true; }
+trap restore_memory EXIT
+gunzip -c "$DUMP" | docker exec -i "$DB_CONTAINER" mysql -uroot -p"$MYSQL_ROOT_PASSWORD" "$DB_NAME"
+restore_memory
+trap - EXIT
+echo "Import complete."
+
+# ── 5. Apply migrations from this checkout ──────────────────────────────────
+echo "=== Applying schema migrations ($PYTHON_BIN) ==="
+$PYTHON_BIN -c "from database import Database; Database.create_tables(); print('Migrations applied')"
+
+echo
+echo "=== Summary ==="
+docker exec "$DB_CONTAINER" mysql -uroot -p"$MYSQL_ROOT_PASSWORD" "$DB_NAME" -N -e \
+    "SELECT CONCAT('researchers: ', COUNT(*)) FROM researchers
+     UNION ALL SELECT CONCAT('papers: ', COUNT(*)) FROM papers
+     UNION ALL SELECT CONCAT('feed_events: ', COUNT(*)) FROM feed_events
+     UNION ALL SELECT CONCAT('latest event: ', COALESCE(MAX(created_at), 'none')) FROM feed_events" 2>/dev/null
+echo "Local DB now mirrors: $(basename "$DUMP")"
+echo "Dump kept at $DUMP — next run reuses it unless a newer backup exists."

--- a/tests/test_feed_event_integrity.py
+++ b/tests/test_feed_event_integrity.py
@@ -1,0 +1,386 @@
+"""Integration tests for feed event guard logic — catches bugs like PR #145, #158, #153.
+
+PR #145: Status regressions generated bogus status_change events.
+PR #158: Bogus new_paper events — 6/24 were false positives (title on page for weeks).
+PR #153: Feed events for backward status transitions.
+
+Tests verify all guards independently AND in combination, with realistic data shapes.
+"""
+import zlib
+import pytest
+from dataclasses import dataclass
+from unittest.mock import patch, MagicMock
+
+from feed_events import (
+    FeedEventEmitter,
+    _title_in_previous_snapshot,
+    _get_previous_snapshot_html,
+    _url_has_baseline,
+)
+
+
+@dataclass
+class FakeSaveResult:
+    paper_id: int
+    title: str
+    is_new: bool
+    new_to_this_url: bool
+    status: str | None
+
+
+def _make_conn_and_cursor(snapshot_count=3, prev_html=None, prior_event_count=0):
+    """Build mock conn/cursor that simulates the guard queries in order.
+
+    Query order in emit_new_paper_events:
+    1. _url_has_baseline → SELECT COUNT(*) FROM html_snapshots
+    2. _get_previous_snapshot_html → SELECT raw_html_compressed FROM html_snapshots
+    Then per-result:
+    3. (if is_new) INSERT INTO feed_events
+    4. (if not is_new) SELECT COUNT(*) FROM feed_events WHERE paper_id=... → prior_event_count
+    """
+    mock_cursor = MagicMock()
+
+    compressed = zlib.compress(prev_html.encode("utf-8")) if prev_html else None
+    fetchone_returns = [
+        (snapshot_count,),
+        (compressed,) if compressed else None,
+    ]
+    if prior_event_count is not None:
+        fetchone_returns.append((prior_event_count,))
+
+    mock_cursor.fetchone.side_effect = fetchone_returns
+    mock_cursor.execute = MagicMock()
+
+    mock_conn = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cursor
+
+    return mock_conn, mock_cursor
+
+
+class TestUrlHasBaseline:
+    """_url_has_baseline guards against first-ever extractions."""
+
+    def test_zero_snapshots_returns_false(self):
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (0,)
+        assert _url_has_baseline(cursor, "http://example.com") is False
+
+    def test_one_snapshot_returns_false(self):
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (1,)
+        assert _url_has_baseline(cursor, "http://example.com") is False
+
+    def test_two_snapshots_returns_true(self):
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (2,)
+        assert _url_has_baseline(cursor, "http://example.com") is True
+
+    def test_many_snapshots_returns_true(self):
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (100,)
+        assert _url_has_baseline(cursor, "http://example.com") is True
+
+    def test_custom_min_snapshots(self):
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (4,)
+        assert _url_has_baseline(cursor, "http://example.com", min_snapshots=5) is False
+        assert _url_has_baseline(cursor, "http://example.com", min_snapshots=4) is True
+
+    def test_null_row_returns_false(self):
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        assert _url_has_baseline(cursor, "http://example.com") is False
+
+
+class TestTitleInPreviousSnapshotEdgeCases:
+    """Title matching edge cases that caused bogus events (PR #158)."""
+
+    def test_title_with_html_entities_in_snapshot(self):
+        """PR #158: titles hidden behind HTML entities must match after the
+        snapshot is normalized (entity decode + tag strip + collapse)."""
+        from feed_events import _normalize_html_for_matching
+        html = "<p>Trade &amp; Wages: Evidence from Germany</p>"
+        normalized = _normalize_html_for_matching(html)
+        result = _title_in_previous_snapshot("Trade & Wages: Evidence from Germany", normalized)
+        assert result is True
+
+    def test_title_split_across_inline_tags(self):
+        """PR #158: titles split by <em>/<b> must match after normalization."""
+        from feed_events import _normalize_html_for_matching
+        html = "<p>Trade and <em>Wages</em>: Evidence from <b>Germany</b></p>"
+        normalized = _normalize_html_for_matching(html)
+        result = _title_in_previous_snapshot("Trade and Wages: Evidence from Germany", normalized)
+        assert result is True
+
+    def test_title_behind_unicode_escapes(self):
+        """PR #158: Google Sites embeds content as \\uXXXX JSON escapes."""
+        from feed_events import _normalize_html_for_matching
+        html = r'{"content":"Trade & Wages: Evidence from Germany"}'
+        normalized = _normalize_html_for_matching(html)
+        result = _title_in_previous_snapshot("Trade & Wages: Evidence from Germany", normalized)
+        assert result is True
+
+    def test_title_substring_match(self):
+        html = "<p>the effect of monetary policy on wages and employment</p>"
+        result = _title_in_previous_snapshot(
+            "The Effect of Monetary Policy on Wages and Employment", html
+        )
+        assert result is True
+
+    def test_title_not_present(self):
+        html = "<p>some completely different paper about trade</p>"
+        result = _title_in_previous_snapshot("Monetary Policy Shocks", html)
+        assert result is False
+
+    def test_empty_title_matches_anything(self):
+        """Empty string is a substring of everything — callers must never pass
+        empty titles (validate_publication drops them upstream)."""
+        html = "<p>anything</p>"
+        result = _title_in_previous_snapshot("", html)
+        assert result is True
+
+    def test_none_html_returns_false(self):
+        result = _title_in_previous_snapshot("Any Title", None)
+        assert result is False
+
+    def test_title_in_json_embedded_html(self):
+        html = '<script>{"content":"monetary policy in the eurozone"}</script>'
+        result = _title_in_previous_snapshot("Monetary Policy in the Eurozone", html.lower())
+        assert result is True
+
+
+class TestGetPreviousSnapshotHtml:
+    """Snapshot retrieval and decompression edge cases."""
+
+    def _make_cursor(self, row):
+        cursor = MagicMock()
+        cursor.fetchone.return_value = row
+        return cursor
+
+    def test_decompresses_and_normalizes(self):
+        """PR #158: returns normalized text (tags stripped, lowercased, collapsed)."""
+        html = "<H1>My Paper Title</H1>"
+        compressed = zlib.compress(html.encode("utf-8"))
+        cursor = self._make_cursor((compressed,))
+        result = _get_previous_snapshot_html(cursor, "http://example.com")
+        assert result == "my paper title"
+
+    def test_none_row_returns_none(self):
+        cursor = self._make_cursor(None)
+        assert _get_previous_snapshot_html(cursor, "http://example.com") is None
+
+    def test_none_blob_returns_none(self):
+        cursor = self._make_cursor((None,))
+        assert _get_previous_snapshot_html(cursor, "http://example.com") is None
+
+    def test_corrupt_zlib_returns_none(self):
+        cursor = self._make_cursor((b"not-valid-zlib",))
+        assert _get_previous_snapshot_html(cursor, "http://example.com") is None
+
+    def test_non_ascii_does_not_crash(self):
+        """Accented chars are collapsed by normalization (non-[a-z0-9] → space);
+        the call must not raise and ASCII stems must survive."""
+        html_bytes = "café résumé naïve".encode("utf-8")
+        compressed = zlib.compress(html_bytes)
+        cursor = self._make_cursor((compressed,))
+        result = _get_previous_snapshot_html(cursor, "http://example.com")
+        assert result is not None
+        assert "caf" in result
+
+
+class TestEmitNewPaperGuardsCombined:
+    """All guards must work together — no single guard bypass allows false events."""
+
+    @patch("feed_events.Database.get_connection")
+    def test_seed_suppresses_regardless_of_other_conditions(self, mock_get_conn):
+        result = FeedEventEmitter.emit_new_paper_events(
+            [FakeSaveResult(1, "Paper", True, True, "working_paper")],
+            url="http://example.com",
+            is_seed=True,
+        )
+        assert result == 0
+        mock_get_conn.assert_not_called()
+
+    @patch("feed_events.Database.get_connection")
+    def test_published_status_suppressed(self, mock_get_conn):
+        conn, cursor = _make_conn_and_cursor(snapshot_count=5, prev_html=None)
+        mock_get_conn.return_value = conn
+        result = FeedEventEmitter.emit_new_paper_events(
+            [FakeSaveResult(1, "Paper", True, True, "published")],
+            url="http://example.com",
+        )
+        assert result == 0
+
+    @patch("feed_events.Database.get_connection")
+    def test_no_baseline_suppresses_working_paper(self, mock_get_conn):
+        conn, cursor = _make_conn_and_cursor(snapshot_count=1, prev_html=None)
+        mock_get_conn.return_value = conn
+        result = FeedEventEmitter.emit_new_paper_events(
+            [FakeSaveResult(1, "New Paper", True, True, "working_paper")],
+            url="http://example.com",
+        )
+        assert result == 0
+
+    @patch("feed_events.Database.get_connection")
+    def test_title_in_prev_snapshot_suppresses(self, mock_get_conn):
+        conn, cursor = _make_conn_and_cursor(
+            snapshot_count=5,
+            prev_html="<p>Trade and Wages: Evidence from Germany</p>",
+        )
+        mock_get_conn.return_value = conn
+        result = FeedEventEmitter.emit_new_paper_events(
+            [FakeSaveResult(1, "Trade and Wages: Evidence from Germany", True, True, "working_paper")],
+            url="http://example.com",
+        )
+        assert result == 0
+
+    @patch("feed_events.Database.get_connection")
+    def test_all_guards_pass_creates_event(self, mock_get_conn):
+        conn, cursor = _make_conn_and_cursor(
+            snapshot_count=5,
+            prev_html="<p>Some Other Paper Title</p>",
+        )
+        mock_get_conn.return_value = conn
+        result = FeedEventEmitter.emit_new_paper_events(
+            [FakeSaveResult(1, "Brand New Paper", True, True, "working_paper")],
+            url="http://example.com",
+        )
+        assert result == 1
+        insert_calls = [
+            c for c in cursor.execute.call_args_list
+            if "INSERT INTO feed_events" in str(c)
+        ]
+        assert len(insert_calls) == 1
+
+    @patch("feed_events.Database.get_connection")
+    def test_none_status_suppressed(self, mock_get_conn):
+        conn, cursor = _make_conn_and_cursor(snapshot_count=5, prev_html=None)
+        mock_get_conn.return_value = conn
+        result = FeedEventEmitter.emit_new_paper_events(
+            [FakeSaveResult(1, "Paper", True, True, None)],
+            url="http://example.com",
+        )
+        assert result == 0
+
+    @patch("feed_events.Database.get_connection")
+    def test_empty_results_list_creates_no_events(self, mock_get_conn):
+        result = FeedEventEmitter.emit_new_paper_events(
+            [], url="http://example.com",
+        )
+        assert result == 0
+        mock_get_conn.assert_not_called()
+
+    @patch("feed_events.Database.get_connection")
+    def test_multiple_papers_mixed_guards(self, mock_get_conn):
+        """Mix of valid and invalid papers: only valid ones get events."""
+        conn, cursor = _make_conn_and_cursor(
+            snapshot_count=5,
+            prev_html="<p>existing paper on page</p>",
+        )
+        mock_get_conn.return_value = conn
+        results = [
+            FakeSaveResult(1, "Existing Paper on Page", True, True, "working_paper"),
+            FakeSaveResult(2, "Published Paper", True, True, "published"),
+            FakeSaveResult(3, "Genuinely New Paper", True, True, "working_paper"),
+        ]
+        count = FeedEventEmitter.emit_new_paper_events(results, url="http://example.com")
+        assert count == 1
+
+
+class TestDuplicatePaperEventGuard:
+    """Duplicate papers (existing paper, new to URL) need dedup check."""
+
+    @patch("feed_events.Database.get_connection")
+    def test_duplicate_with_prior_event_suppressed(self, mock_get_conn):
+        conn, cursor = _make_conn_and_cursor(
+            snapshot_count=5,
+            prev_html=None,
+            prior_event_count=1,
+        )
+        mock_get_conn.return_value = conn
+        result = FeedEventEmitter.emit_new_paper_events(
+            [FakeSaveResult(10, "Existing Paper", False, True, "working_paper")],
+            url="http://example.com",
+        )
+        assert result == 0
+
+    @patch("feed_events.Database.get_connection")
+    def test_duplicate_without_prior_event_creates(self, mock_get_conn):
+        conn, cursor = _make_conn_and_cursor(
+            snapshot_count=5,
+            prev_html=None,
+            prior_event_count=0,
+        )
+        mock_get_conn.return_value = conn
+        result = FeedEventEmitter.emit_new_paper_events(
+            [FakeSaveResult(10, "Existing Paper", False, True, "working_paper")],
+            url="http://example.com",
+        )
+        assert result == 1
+
+
+class TestStatusChangeEventIntegrity:
+    """Status change events must only fire for forward progressions (PR #153)."""
+
+    @patch("feed_events.Database.get_connection")
+    def test_forward_progression_creates_event(self, mock_get_conn):
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        cursor = MagicMock()
+        conn.cursor.return_value = cursor
+        mock_get_conn.return_value = conn
+
+        FeedEventEmitter.emit_status_change(1, "working_paper", "accepted")
+        insert_calls = [
+            c for c in cursor.execute.call_args_list
+            if "status_change" in str(c)
+        ]
+        assert len(insert_calls) == 1
+
+    @patch("feed_events.Database.get_connection")
+    def test_event_stores_both_statuses(self, mock_get_conn):
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        cursor = MagicMock()
+        conn.cursor.return_value = cursor
+        mock_get_conn.return_value = conn
+
+        FeedEventEmitter.emit_status_change(1, "working_paper", "published")
+        args = cursor.execute.call_args[0][1]
+        assert "working_paper" in args
+        assert "published" in args
+
+
+class TestTitleChangeEventIntegrity:
+    """Title change events store old and new titles."""
+
+    @patch("feed_events.Database.get_connection")
+    def test_title_change_stores_both_titles(self, mock_get_conn):
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        cursor = MagicMock()
+        conn.cursor.return_value = cursor
+        mock_get_conn.return_value = conn
+
+        FeedEventEmitter.emit_title_change(1, "Old Title", "New Title")
+        args = cursor.execute.call_args[0][1]
+        assert "Old Title" in args
+        assert "New Title" in args
+
+    @patch("feed_events.Database.get_connection")
+    def test_title_change_event_type(self, mock_get_conn):
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        cursor = MagicMock()
+        conn.cursor.return_value = cursor
+        mock_get_conn.return_value = conn
+
+        FeedEventEmitter.emit_title_change(1, "A", "B")
+        sql = cursor.execute.call_args[0][0]
+        assert "title_change" in sql

--- a/tests/test_html_fetcher.py
+++ b/tests/test_html_fetcher.py
@@ -465,3 +465,29 @@ class TestGetExtractionPayload:
     def test_returns_none_when_no_html(self):
         with patch("html_fetcher.Database.fetch_one", return_value=None):
             assert HTMLFetcher.get_extraction_payload(7) is None
+
+
+class TestUnchangedPathBackfill:
+    """The unchanged-hash path must backfill missing bodies (data-quality finding
+    2026-06-11: 4,536 prod rows had content_hash but NULL content — restored from
+    a metadata-only dump — and extraction looped on no_content forever because
+    the matching hash meant the save path never ran)."""
+
+    @patch("html_fetcher.Database.execute_query")
+    def test_touch_unchanged_backfills_content_and_raw_html(self, mock_execute):
+        HTMLFetcher._touch_unchanged(42, "<html>raw</html>", "page text")
+        sql, params = mock_execute.call_args[0]
+        assert "COALESCE(raw_html" in sql
+        assert "content IS NULL OR content = ''" in sql
+        assert "timestamp" in sql
+        assert params[-1] == 42  # url_id is the WHERE param
+        assert "<html>raw</html>" in params
+        assert "page text" in params
+
+    @patch("html_fetcher.Database.execute_query")
+    def test_touch_unchanged_preserves_existing_content(self, mock_execute):
+        """Backfill must be conditional (IF/COALESCE), never an unconditional overwrite."""
+        HTMLFetcher._touch_unchanged(42, "<html/>", "text")
+        sql, _ = mock_execute.call_args[0]
+        assert "SET timestamp" in sql
+        assert "content = IF(content IS NULL OR content = ''" in sql

--- a/tests/test_researcher_search_guards.py
+++ b/tests/test_researcher_search_guards.py
@@ -1,0 +1,111 @@
+"""Tests for researcher search SQL guard conditions — catches bugs like PR #152, #147.
+
+PR #152: zero-publication coauthors (imported via OpenAlex enrichment) appeared in directory.
+PR #147: initial-only names ("A." "B.") appeared as valid researchers.
+
+These tests verify the SQL WHERE clause structure, not the data — no DB needed.
+"""
+import pytest
+from unittest.mock import patch
+
+
+def _get_sql(**kwargs):
+    """Call search_researchers with mocked fetch_all and return the SQL string + params."""
+    with patch("database.researchers.fetch_all", return_value=[]) as mock_fetch:
+        from database.researchers import search_researchers
+        search_researchers(**kwargs)
+    sql, params = mock_fetch.call_args[0]
+    return sql, params
+
+
+class TestCoauthorGuard:
+    """Coauthor-only researchers must be hidden from directory (PR #152)."""
+
+    def test_authorship_exists_clause_present(self):
+        sql, _ = _get_sql()
+        assert "EXISTS (SELECT 1 FROM authorship" in sql
+
+    def test_authorship_references_researcher_id(self):
+        sql, _ = _get_sql()
+        assert "a.researcher_id = r.id" in sql
+
+    def test_authorship_guard_not_removed_by_filters(self):
+        """Guard must persist even when other filters are active."""
+        for kwargs in [
+            {"institution": "MIT"},
+            {"search": "Smith"},
+            {"field_slug": "labor"},
+            {"preset": "top20"},
+            {"position": "Professor"},
+        ]:
+            sql, _ = _get_sql(**kwargs)
+            assert "EXISTS (SELECT 1 FROM authorship" in sql, (
+                f"authorship guard missing when filter={kwargs}"
+            )
+
+
+class TestInitialOnlyNameGuard:
+    """Initial-only names (e.g., "A.", "B. C.") must be hidden."""
+
+    def test_first_name_char_length_guard(self):
+        sql, _ = _get_sql()
+        assert "CHAR_LENGTH(r.first_name) > 2" in sql
+
+    def test_last_name_char_length_guard(self):
+        sql, _ = _get_sql()
+        assert "CHAR_LENGTH(r.last_name) > 2" in sql
+
+    def test_first_name_regexp_guard(self):
+        sql, _ = _get_sql()
+        assert "r.first_name NOT REGEXP" in sql
+
+    def test_last_name_regexp_guard(self):
+        sql, _ = _get_sql()
+        assert "r.last_name NOT REGEXP" in sql
+
+    def test_null_names_guarded(self):
+        sql, _ = _get_sql()
+        assert "r.first_name IS NOT NULL" in sql
+        assert "r.last_name IS NOT NULL" in sql
+
+
+class TestValidationGuard:
+    """Only researchers with openalex_author_id OR researcher_urls are shown."""
+
+    def test_openalex_or_urls_guard_present(self):
+        sql, _ = _get_sql()
+        assert "openalex_author_id IS NOT NULL" in sql
+        assert "researcher_urls" in sql
+
+    def test_guard_is_or_condition(self):
+        """Must be OR (either openalex_author_id OR urls), not AND."""
+        sql, _ = _get_sql()
+        openalex_pos = sql.find("openalex_author_id IS NOT NULL")
+        urls_pos = sql.find("SELECT 1 FROM researcher_urls")
+        between = sql[openalex_pos:urls_pos]
+        assert "OR" in between
+
+
+class TestGuardsNotRemovableByPagination:
+    """Guards must be present regardless of pagination params."""
+
+    def test_guards_with_offset_and_limit(self):
+        sql, _ = _get_sql(offset=100, limit=50)
+        assert "EXISTS (SELECT 1 FROM authorship" in sql
+        assert "CHAR_LENGTH(r.first_name) > 2" in sql
+        assert "openalex_author_id IS NOT NULL" in sql
+
+
+class TestGuardsCombinedWithUserFilters:
+    """All three guards must coexist with user-supplied filters."""
+
+    def test_all_guards_present_with_all_filters(self):
+        sql, _ = _get_sql(
+            institution="MIT",
+            search="Smith",
+            field_slug="labor",
+        )
+        assert "EXISTS (SELECT 1 FROM authorship" in sql
+        assert "CHAR_LENGTH(r.first_name) > 2" in sql
+        assert "openalex_author_id IS NOT NULL" in sql
+        assert "r.affiliation LIKE %s" in sql

--- a/tests/test_status_progression.py
+++ b/tests/test_status_progression.py
@@ -1,0 +1,120 @@
+"""Exhaustive status progression tests — catches bugs like PR #153 (status regressions).
+
+Tests every pairwise status transition to ensure:
+- Only forward progressions are recognized
+- Regressions are blocked on the papers table
+- Raw LLM status is always stored in snapshots for audit
+- PaperSnapshotResult.status_changed is correct for all combinations
+"""
+import pytest
+from database.snapshots import _is_status_progression, _STATUS_RANK, PaperSnapshotResult
+
+
+ALL_STATUSES = list(_STATUS_RANK.keys())
+
+
+class TestStatusRankIntegrity:
+    """The status hierarchy must be strict and complete."""
+
+    def test_rank_is_strictly_ordered(self):
+        ranks = list(_STATUS_RANK.values())
+        assert ranks == sorted(ranks)
+        assert len(set(ranks)) == len(ranks)
+
+    def test_all_five_statuses_present(self):
+        expected = {'working_paper', 'reject_and_resubmit', 'revise_and_resubmit', 'accepted', 'published'}
+        assert set(_STATUS_RANK.keys()) == expected
+
+    def test_working_paper_is_lowest(self):
+        assert _STATUS_RANK['working_paper'] == min(_STATUS_RANK.values())
+
+    def test_published_is_highest(self):
+        assert _STATUS_RANK['published'] == max(_STATUS_RANK.values())
+
+
+class TestIsStatusProgressionExhaustive:
+    """Every pairwise combination of statuses must be classified correctly."""
+
+    @pytest.mark.parametrize("old,new", [
+        (old, new)
+        for old in ALL_STATUSES
+        for new in ALL_STATUSES
+        if _STATUS_RANK[new] > _STATUS_RANK[old]
+    ])
+    def test_forward_progressions(self, old, new):
+        assert _is_status_progression(old, new) is True
+
+    @pytest.mark.parametrize("old,new", [
+        (old, new)
+        for old in ALL_STATUSES
+        for new in ALL_STATUSES
+        if _STATUS_RANK[new] < _STATUS_RANK[old]
+    ])
+    def test_backward_regressions(self, old, new):
+        assert _is_status_progression(old, new) is False
+
+    @pytest.mark.parametrize("status", ALL_STATUSES)
+    def test_same_status_is_not_progression(self, status):
+        assert _is_status_progression(status, status) is False
+
+    @pytest.mark.parametrize("status", ALL_STATUSES)
+    def test_none_to_status_is_not_progression(self, status):
+        assert _is_status_progression(None, status) is False
+
+    @pytest.mark.parametrize("status", ALL_STATUSES)
+    def test_status_to_none_is_not_progression(self, status):
+        assert _is_status_progression(status, None) is False
+
+    def test_none_to_none(self):
+        assert _is_status_progression(None, None) is False
+
+    def test_unknown_status_treated_as_regression(self):
+        assert _is_status_progression("accepted", "unknown_status") is False
+
+    def test_unknown_to_known_is_progression(self):
+        """Unknown status gets rank -1, so any known status outranks it."""
+        assert _is_status_progression("unknown", "published") is True
+
+
+class TestPaperSnapshotResultStatusChanged:
+    """PaperSnapshotResult.status_changed delegates to _is_status_progression."""
+
+    def test_forward_progression_is_changed(self):
+        r = PaperSnapshotResult(changed=True, old_status="working_paper", new_status="accepted")
+        assert r.status_changed is True
+
+    def test_backward_regression_is_not_changed(self):
+        r = PaperSnapshotResult(changed=True, old_status="published", new_status="working_paper")
+        assert r.status_changed is False
+
+    def test_same_status_is_not_changed(self):
+        r = PaperSnapshotResult(changed=True, old_status="accepted", new_status="accepted")
+        assert r.status_changed is False
+
+    def test_none_old_status_is_not_changed(self):
+        r = PaperSnapshotResult(changed=True, old_status=None, new_status="working_paper")
+        assert r.status_changed is False
+
+    def test_unchanged_snapshot_has_no_status_change(self):
+        r = PaperSnapshotResult(changed=False)
+        assert r.status_changed is False
+
+    @pytest.mark.parametrize("old,new", [
+        ("working_paper", "reject_and_resubmit"),
+        ("reject_and_resubmit", "revise_and_resubmit"),
+        ("revise_and_resubmit", "accepted"),
+        ("accepted", "published"),
+    ])
+    def test_each_single_step_forward(self, old, new):
+        r = PaperSnapshotResult(changed=True, old_status=old, new_status=new)
+        assert r.status_changed is True
+
+    @pytest.mark.parametrize("old,new", [
+        ("reject_and_resubmit", "working_paper"),
+        ("revise_and_resubmit", "reject_and_resubmit"),
+        ("accepted", "revise_and_resubmit"),
+        ("published", "accepted"),
+    ])
+    def test_each_single_step_backward(self, old, new):
+        r = PaperSnapshotResult(changed=True, old_status=old, new_status=new)
+        assert r.status_changed is False

--- a/tests/test_title_cleaning.py
+++ b/tests/test_title_cleaning.py
@@ -1,0 +1,152 @@
+"""Tests for title cleaning, normalization, and year coercion — catches bugs like PR #151, #146.
+
+PR #151: CSS-styled pages yielded lowercase titles stored as-is.
+PR #146: 65% of new_paper events had NULL year because the LLM returned non-standard formats.
+"""
+import pytest
+from publication import clean_title, PublicationExtraction
+from database.papers import normalize_title, compute_title_hash
+
+
+class TestCleanTitleCapitalization:
+    """clean_title() must capitalize the first letter (PR #151)."""
+
+    def test_lowercase_title_gets_capitalized(self):
+        assert clean_title("monetary policy in europe") == "Monetary policy in europe"
+
+    def test_already_capitalized_is_unchanged(self):
+        assert clean_title("Monetary Policy in Europe") == "Monetary Policy in Europe"
+
+    def test_all_caps_is_unchanged(self):
+        assert clean_title("MONETARY POLICY") == "MONETARY POLICY"
+
+    def test_numeric_start_is_unchanged(self):
+        assert clean_title("3rd wave of immigration") == "3rd wave of immigration"
+
+    def test_quoted_start_is_unchanged(self):
+        assert clean_title('"quoted title" in economics') == '"quoted title" in economics'
+
+    def test_empty_string_returns_empty(self):
+        assert clean_title("") == ""
+
+    def test_whitespace_only_returns_empty(self):
+        assert clean_title("   ") == ""
+
+    def test_single_char_lowercase(self):
+        assert clean_title("x") == "X"
+
+
+class TestCleanTitleMetadataStripping:
+    """clean_title() strips metadata suffixes before capitalizing."""
+
+    @pytest.mark.parametrize("suffix", [
+        " — Working Paper",
+        " -- JMP",
+        " – Draft",
+        " — Job Market Paper",
+        " — New",
+        " — Revised",
+        " — Forthcoming",
+        " — Under Review",
+        " — R&R",
+    ])
+    def test_dash_suffixes_stripped(self, suffix):
+        result = clean_title(f"My Paper Title{suffix}")
+        assert result == "My Paper Title"
+
+    @pytest.mark.parametrize("suffix", [
+        " [Working Paper]",
+        " [JMP]",
+        " [Draft]",
+        " (Working Paper)",
+        " (New!)",
+        " [Revised]",
+        " [Updated]",
+        " (Submitted)",
+    ])
+    def test_bracket_suffixes_stripped(self, suffix):
+        result = clean_title(f"My Paper Title{suffix}")
+        assert result == "My Paper Title"
+
+    def test_metadata_stripped_before_capitalization(self):
+        result = clean_title("trade and wages — working paper")
+        assert result == "Trade and wages"
+
+    def test_no_metadata_preserved(self):
+        assert clean_title("Trade and Wages") == "Trade and Wages"
+
+
+class TestNormalizeTitleDedup:
+    """normalize_title() for dedup hashing (PR #151 notes title_hash unaffected)."""
+
+    def test_lowercase_and_strip_punctuation(self):
+        assert normalize_title("Trade & Wages: Evidence") == "trade wages evidence"
+
+    def test_collapse_whitespace(self):
+        assert normalize_title("Trade   and   Wages") == "trade and wages"
+
+    def test_case_insensitive_dedup(self):
+        assert normalize_title("TRADE AND WAGES") == normalize_title("trade and wages")
+
+    def test_punctuation_stripped_for_dedup(self):
+        """Punctuation like '&' is stripped — 'Trade & Wages' normalizes to 'trade wages'."""
+        assert normalize_title("Trade & Wages") == "trade wages"
+
+    def test_none_returns_empty(self):
+        assert normalize_title(None) == ""
+
+    def test_empty_returns_empty(self):
+        assert normalize_title("") == ""
+
+    def test_hash_stable_across_case_variants(self):
+        h1 = compute_title_hash("My Paper Title")
+        h2 = compute_title_hash("my paper title")
+        assert h1 == h2
+
+    def test_hash_stable_across_punctuation_variants(self):
+        h1 = compute_title_hash("Trade & Wages: Evidence from Germany")
+        h2 = compute_title_hash("Trade  Wages Evidence from Germany")
+        assert h1 == h2
+
+
+class TestYearCoercion:
+    """PublicationExtraction.coerce_year_to_str handles non-standard year formats (PR #146)."""
+
+    @pytest.mark.parametrize("input_val,expected", [
+        ("2024", "2024"),
+        (2024, "2024"),
+        ("2024a", "2024"),
+        ("forthcoming 2025", "2025"),
+        ("2023-24", "2023"),
+        ("Revised 2024", "2024"),
+        (None, None),
+        ("", None),
+        ("   ", None),
+    ])
+    def test_year_coercion(self, input_val, expected):
+        result = PublicationExtraction.coerce_year_to_str(input_val)
+        assert result == expected
+
+    def test_full_model_with_integer_year(self):
+        pub = PublicationExtraction(
+            title="Test Paper",
+            authors=[["Jane", "Doe"]],
+            year=2024,
+        )
+        assert pub.year == "2024"
+
+    def test_full_model_with_forthcoming_year(self):
+        pub = PublicationExtraction(
+            title="Test Paper",
+            authors=[["Jane", "Doe"]],
+            year="forthcoming 2025",
+        )
+        assert pub.year == "2025"
+
+    def test_full_model_with_none_year(self):
+        pub = PublicationExtraction(
+            title="Test Paper",
+            authors=[["Jane", "Doe"]],
+            year=None,
+        )
+        assert pub.year is None

--- a/tests_data_quality/conftest.py
+++ b/tests_data_quality/conftest.py
@@ -1,0 +1,84 @@
+"""Data-quality invariant checks that run against the REAL database.
+
+Unlike tests/ (mocked, fast, run by `make check`), this suite connects to the
+database configured in .env and fails when stored data violates invariants
+that past production incidents established. Run with:
+
+    make check-data            # or: poetry run pytest tests_data_quality -v
+
+Each test names the incident it guards against (PR/issue number). A failure
+is not a code bug — it is a triage list of bad rows in the database.
+
+The suite skips itself when no database is reachable, so it is safe to
+invoke anywhere; it is intentionally NOT part of `testpaths` in pyproject.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from dotenv import load_dotenv
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+# db_config.py hard-requires these at import; only the DB_* values are actually
+# used here. Placeholders keep collection alive when .env is partial — the
+# session fixture below still skips if the DB itself is unreachable.
+os.environ.setdefault("GOOGLE_API_KEY", "data-quality-placeholder")
+os.environ.setdefault("SCRAPE_API_KEY", "data-quality-placeholder")
+os.environ.setdefault("CONTENT_MAX_CHARS", "20000")
+
+_MISSING_DB_VARS = [v for v in ("DB_HOST", "DB_USER", "DB_PASSWORD", "DB_NAME") if not os.environ.get(v)]
+
+# Ranks must mirror database/snapshots.py::_STATUS_RANK
+STATUS_ORDER = "'working_paper','reject_and_resubmit','revise_and_resubmit','accepted','published'"
+
+# Earliest plausible feed event — the project started scraping in 2025.
+PROJECT_EPOCH = "2025-01-01"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_database():
+    if _MISSING_DB_VARS:
+        pytest.skip(f"No database configured: missing {', '.join(_MISSING_DB_VARS)} in .env")
+    try:
+        from database.connection import get_connection
+
+        conn = get_connection()
+        conn.close()
+    except Exception as exc:  # connection refused, bad credentials, missing schema…
+        pytest.skip(f"Database not reachable: {exc}")
+
+
+@pytest.fixture(scope="session")
+def db(_require_database):
+    """Thin query interface over the real connection pool."""
+    from types import SimpleNamespace
+
+    from database.connection import fetch_all, fetch_one
+
+    return SimpleNamespace(fetch_all=fetch_all, fetch_one=fetch_one)
+
+
+def mojibake_condition(column: str) -> str:
+    """SQL condition matching UTF-8-as-latin1 mojibake bigrams in a column.
+
+    A bare 'Ã' is legitimate (Portuguese SÃO, COGNIÇÃO); only 'Ã' followed by
+    a latin-1 symbol byte — or the 'â€' smart-punctuation prefix — is mojibake.
+    LIKE BINARY is used because MySQL 8.4 rejects REGEXP BINARY on utf8mb4.
+    """
+    bigrams = ["â€", "Ã©", "Ã¨", "Ã¡", "Ã³", "Ãº", "Ã­", "Ã§", "Ã£", "Ã¶", "Ã¼", "Ã±", "Ã¤", "Ã¸", "Ã¥"]
+    return "(" + " OR ".join(f"{column} LIKE BINARY '%{b}%'" for b in bigrams) + ")"
+
+
+def fmt_violations(rows: list[dict], total: int | None = None, limit: int = 15) -> str:
+    """Render offending rows into an actionable failure message."""
+    total = total if total is not None else len(rows)
+    lines = [f"{total} violating row(s); first {min(len(rows), limit)}:"]
+    for row in rows[:limit]:
+        lines.append("  " + ", ".join(f"{k}={v!r}" for k, v in row.items()))
+    return "\n".join(lines)

--- a/tests_data_quality/test_feed_event_quality.py
+++ b/tests_data_quality/test_feed_event_quality.py
@@ -1,0 +1,184 @@
+"""Feed event invariants against the real database.
+
+These automate the manual spot-checks that found real production incidents:
+PR #158 found 6 of 24 recent new_paper events were bogus; FE#3187 violated
+the baseline guard; PR #153 found regression status_change events.
+"""
+import zlib
+
+from conftest import STATUS_ORDER, PROJECT_EPOCH, fmt_violations
+
+
+class TestNewPaperBaselineGuard:
+    """Every new_paper event's source URL must have had >= 2 HTML snapshots.
+
+    Guards the FE#3187 incident: an event inserted for a URL with zero
+    snapshots (the DB trigger did not exist in prod for months, PR #158).
+    The 1-hour slack covers the snapshot archived by the same fetch that
+    triggered the event (event_date is the fetch timestamp since PR #144).
+    """
+
+    def test_no_new_paper_events_without_snapshot_baseline(self, db):
+        rows = db.fetch_all(
+            f"""
+            SELECT fe.id, fe.paper_id, fe.created_at, p.source_url
+            FROM feed_events fe
+            JOIN papers p ON p.id = fe.paper_id
+            WHERE fe.event_type = 'new_paper'
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM researcher_urls ru
+                  JOIN html_snapshots hs ON hs.url_id = ru.id
+                  WHERE ru.url = p.source_url
+                    AND hs.snapshot_at <= fe.created_at + INTERVAL 1 HOUR
+                  GROUP BY ru.id
+                  HAVING COUNT(*) >= 2
+              )
+            ORDER BY fe.created_at DESC
+            """
+        )
+        assert not rows, "new_paper events on URLs lacking a 2-snapshot baseline:\n" + fmt_violations(rows)
+
+
+class TestStatusChangeProgression:
+    """status_change events may only record forward progressions (PR #153)."""
+
+    def test_no_regression_status_change_events(self, db):
+        rows = db.fetch_all(
+            f"""
+            SELECT id, paper_id, old_status, new_status, created_at
+            FROM feed_events
+            WHERE event_type = 'status_change'
+              AND old_status IS NOT NULL AND new_status IS NOT NULL
+              AND FIELD(old_status, {STATUS_ORDER}) >= FIELD(new_status, {STATUS_ORDER})
+            ORDER BY created_at DESC
+            """
+        )
+        assert not rows, "status_change events that are regressions or no-ops:\n" + fmt_violations(rows)
+
+    def test_status_change_events_have_both_statuses(self, db):
+        """emit_status_change always writes both; NULLs mean a broken writer."""
+        rows = db.fetch_all(
+            """
+            SELECT id, paper_id, old_status, new_status, created_at
+            FROM feed_events
+            WHERE event_type = 'status_change'
+              AND (old_status IS NULL OR new_status IS NULL)
+            """
+        )
+        assert not rows, "status_change events missing old/new status:\n" + fmt_violations(rows)
+
+
+class TestNewPaperStatusGuard:
+    """new_paper events are suppressed for published papers (issue #89 guard)."""
+
+    def test_no_new_paper_events_with_published_status(self, db):
+        rows = db.fetch_all(
+            """
+            SELECT id, paper_id, new_status, created_at
+            FROM feed_events
+            WHERE event_type = 'new_paper' AND new_status = 'published'
+            """
+        )
+        assert not rows, "new_paper events for published papers:\n" + fmt_violations(rows)
+
+    def test_no_new_paper_events_for_seed_papers(self, db):
+        """is_seed papers are first-ever extractions; events for them are noise."""
+        rows = db.fetch_all(
+            """
+            SELECT fe.id, fe.paper_id, fe.created_at
+            FROM feed_events fe
+            JOIN papers p ON p.id = fe.paper_id
+            WHERE fe.event_type = 'new_paper' AND p.is_seed = TRUE
+            """
+        )
+        assert not rows, "new_paper events for seed papers:\n" + fmt_violations(rows)
+
+
+class TestEventDateSanity:
+    """Event dates must be plausible (PR #144 changed event dating)."""
+
+    def test_no_future_dated_events(self, db):
+        rows = db.fetch_all(
+            "SELECT id, paper_id, event_type, created_at FROM feed_events "
+            "WHERE created_at > NOW() + INTERVAL 1 DAY"
+        )
+        assert not rows, "future-dated feed events:\n" + fmt_violations(rows)
+
+    def test_no_events_before_project_epoch(self, db):
+        rows = db.fetch_all(
+            f"SELECT id, paper_id, event_type, created_at FROM feed_events "
+            f"WHERE created_at < '{PROJECT_EPOCH}'"
+        )
+        assert not rows, "events dated before the project existed:\n" + fmt_violations(rows)
+
+
+class TestNoDuplicateNewPaperEvents:
+    """A paper gets at most one new_paper event (dedup guard in emitter)."""
+
+    def test_no_paper_has_multiple_new_paper_events(self, db):
+        rows = db.fetch_all(
+            """
+            SELECT paper_id, COUNT(*) AS event_count
+            FROM feed_events
+            WHERE event_type = 'new_paper'
+            GROUP BY paper_id
+            HAVING COUNT(*) > 1
+            ORDER BY event_count DESC
+            """
+        )
+        assert not rows, "papers with duplicate new_paper events:\n" + fmt_violations(rows)
+
+
+class TestRecentNewPaperEventsAgainstSnapshots:
+    """Automated version of the PR #158 spot check that found 6/24 bogus events.
+
+    For the most recent new_paper events, decompress the HTML snapshot that
+    was current just before the event and check whether the paper title was
+    already on the page — using the same normalization as production
+    (feed_events._normalize_html_for_matching / _normalize_for_matching).
+    """
+
+    SAMPLE_SIZE = 25
+
+    def test_recent_new_paper_titles_absent_from_prior_snapshot(self, db):
+        from feed_events import _normalize_for_matching, _normalize_html_for_matching
+
+        events = db.fetch_all(
+            f"""
+            SELECT fe.id AS event_id, fe.paper_id, fe.created_at, p.title, p.source_url
+            FROM feed_events fe
+            JOIN papers p ON p.id = fe.paper_id
+            WHERE fe.event_type = 'new_paper' AND p.source_url IS NOT NULL
+            ORDER BY fe.created_at DESC
+            LIMIT {self.SAMPLE_SIZE}
+            """
+        )
+        bogus = []
+        for ev in events:
+            snap = db.fetch_one(
+                """
+                SELECT hs.raw_html_compressed
+                FROM html_snapshots hs
+                JOIN researcher_urls ru ON ru.id = hs.url_id
+                WHERE ru.url = %s AND hs.snapshot_at < %s
+                ORDER BY hs.snapshot_at DESC
+                LIMIT 1
+                """,
+                (ev["source_url"], ev["created_at"]),
+            )
+            if not snap or not snap["raw_html_compressed"]:
+                continue
+            try:
+                raw = zlib.decompress(snap["raw_html_compressed"]).decode("utf-8", errors="replace")
+            except Exception:
+                continue
+            if _normalize_for_matching(ev["title"]) in _normalize_html_for_matching(raw):
+                bogus.append(
+                    {"event_id": ev["event_id"], "paper_id": ev["paper_id"],
+                     "created_at": ev["created_at"], "title": ev["title"][:80]}
+                )
+        assert not bogus, (
+            f"{len(bogus)}/{len(events)} recent new_paper events have titles that were "
+            "already on the page in the prior snapshot (bogus events):\n" + fmt_violations(bogus)
+        )

--- a/tests_data_quality/test_paper_quality.py
+++ b/tests_data_quality/test_paper_quality.py
@@ -1,0 +1,138 @@
+"""Paper field invariants against the real database.
+
+Guards: issue #148 (lowercase titles), issue #146 (NULL years), PR #153
+(status regressions on the denormalized papers table), encoding incidents.
+"""
+from conftest import STATUS_ORDER, fmt_violations, mojibake_condition
+
+
+class TestTitleQuality:
+    """clean_title() capitalizes on save; the #151 migration backfilled old rows."""
+
+    def test_no_titles_starting_with_lowercase_letter(self, db):
+        # ORD() of the first character is collation-independent; 97-122 = a-z.
+        rows = db.fetch_all(
+            """
+            SELECT id, title, source_url
+            FROM papers
+            WHERE title IS NOT NULL
+              AND ORD(SUBSTRING(title, 1, 1)) BETWEEN 97 AND 122
+            LIMIT 50
+            """
+        )
+        assert not rows, "papers with lowercase first letter (issue #148):\n" + fmt_violations(rows)
+
+    def test_no_empty_or_whitespace_titles(self, db):
+        rows = db.fetch_all(
+            "SELECT id, title, source_url FROM papers "
+            "WHERE title IS NULL OR TRIM(title) = '' LIMIT 50"
+        )
+        assert not rows, "papers with empty titles:\n" + fmt_violations(rows)
+
+    def test_no_mojibake_in_titles(self, db):
+        """UTF-8 read as latin-1 leaves 'Ã'+symbol or 'â€' bigrams in text."""
+        rows = db.fetch_all(
+            f"SELECT id, title FROM papers WHERE {mojibake_condition('title')} LIMIT 50"
+        )
+        assert not rows, "papers with mojibake titles:\n" + fmt_violations(rows)
+
+    def test_no_metadata_suffixes_in_titles(self, db):
+        """clean_title() strips ' — Working Paper' / '[JMP]' style suffixes on save."""
+        rows = db.fetch_all(
+            r"""
+            SELECT id, title FROM papers
+            WHERE title REGEXP '\\[(JMP|Draft|Working Paper|New!?)\\]$'
+               OR title REGEXP '(--|—|–)[[:space:]]*(JMP|Working Paper|Job Market Paper|Draft)$'
+            LIMIT 50
+            """
+        )
+        assert not rows, "papers with unstripped metadata suffixes:\n" + fmt_violations(rows)
+
+
+class TestYearQuality:
+    """Issue #146: 65% of new_paper events had NULL year. PR #154 tightened the prompt."""
+
+    # Target after PR #154's prompt fix + re-extraction of the backlog.
+    MAX_NULL_YEAR_RATE = 0.50
+
+    def test_year_values_are_four_digit_years(self, db):
+        """The Pydantic validator falls back to s[:4], which can store garbage
+        like 'fort' (from 'forthcoming') — those rows are data corruption."""
+        rows = db.fetch_all(
+            """
+            SELECT id, year, title FROM papers
+            WHERE year IS NOT NULL
+              AND year NOT REGEXP '^(19|20)[0-9]{2}$'
+            LIMIT 50
+            """
+        )
+        assert not rows, "papers with non-year garbage in year column:\n" + fmt_violations(rows)
+
+    def test_null_year_rate_below_threshold(self, db):
+        row = db.fetch_one(
+            "SELECT COUNT(*) AS total, SUM(year IS NULL) AS null_years FROM papers"
+        )
+        total, null_years = row["total"], int(row["null_years"] or 0)
+        if total == 0:
+            return
+        rate = null_years / total
+        assert rate <= self.MAX_NULL_YEAR_RATE, (
+            f"{null_years}/{total} papers ({rate:.0%}) have NULL year — "
+            f"threshold is {self.MAX_NULL_YEAR_RATE:.0%} (issue #146; "
+            "re-run extraction backlog or improve the prompt)"
+        )
+
+    def test_no_implausible_years(self, db):
+        rows = db.fetch_all(
+            """
+            SELECT id, year, title FROM papers
+            WHERE year IS NOT NULL
+              AND year REGEXP '^(19|20)[0-9]{2}$'
+              AND (CAST(year AS UNSIGNED) < 1900
+                   OR CAST(year AS UNSIGNED) > YEAR(NOW()) + 2)
+            LIMIT 50
+            """
+        )
+        assert not rows, "papers with implausible years:\n" + fmt_violations(rows)
+
+
+class TestStatusDenormalizationIntegrity:
+    """papers.status must never be outranked by any of its snapshots (PR #153).
+
+    append_paper_snapshot keeps the highest-ranked status on the papers table;
+    a paper whose snapshot outranks its current status means a regression was
+    applied (pre-#153 damage, or writes bypassing the guard).
+    """
+
+    def test_paper_status_not_outranked_by_snapshots(self, db):
+        rows = db.fetch_all(
+            f"""
+            SELECT p.id, p.status AS paper_status,
+                   MAX(FIELD(ps.status, {STATUS_ORDER})) AS max_snapshot_rank,
+                   FIELD(p.status, {STATUS_ORDER}) AS paper_rank
+            FROM papers p
+            JOIN paper_snapshots ps ON ps.paper_id = p.id
+            WHERE ps.status IS NOT NULL AND p.status IS NOT NULL
+            GROUP BY p.id, p.status
+            HAVING paper_rank < max_snapshot_rank
+            LIMIT 50
+            """
+        )
+        assert not rows, (
+            "papers whose status regressed below a snapshot status (PR #153):\n" + fmt_violations(rows)
+        )
+
+
+class TestPaperRelationalIntegrity:
+    """Every paper must be reachable: at least one author."""
+
+    def test_no_orphan_papers_without_authorship(self, db):
+        rows = db.fetch_all(
+            """
+            SELECT p.id, p.title, p.source_url
+            FROM papers p
+            WHERE NOT EXISTS (SELECT 1 FROM authorship a WHERE a.publication_id = p.id)
+            LIMIT 50
+            """
+        )
+        assert not rows, "papers with no authors (unreachable from any researcher):\n" + fmt_violations(rows)

--- a/tests_data_quality/test_researcher_quality.py
+++ b/tests_data_quality/test_researcher_quality.py
@@ -1,0 +1,127 @@
+"""Researcher data invariants + live checks of what the directory page serves.
+
+Guards: issue #147/#152 (zero-publication coauthors in the directory),
+issue #150 (NULL affiliations), encoding incidents in names.
+
+The directory tests call the REAL search_researchers() against the real
+database — the same code path the /researchers page renders — so they catch
+both SQL-guard regressions and bad rows that slip through.
+"""
+from conftest import fmt_violations, mojibake_condition
+
+
+class TestDirectoryServesValidResearchers:
+    """What /researchers actually returns must satisfy the PR #152 guards."""
+
+    PAGE_SIZE = 500
+
+    def _directory_rows(self):
+        from database.researchers import search_researchers
+
+        rows, total = search_researchers(offset=0, limit=self.PAGE_SIZE)
+        return rows, total
+
+    def test_every_directory_researcher_has_a_publication(self, db):
+        rows, _ = self._directory_rows()
+        if not rows:
+            return
+        ids = [r["id"] for r in rows]
+        placeholders = ",".join(["%s"] * len(ids))
+        counts = db.fetch_all(
+            f"SELECT researcher_id, COUNT(*) AS cnt FROM authorship "
+            f"WHERE researcher_id IN ({placeholders}) GROUP BY researcher_id",
+            tuple(ids),
+        )
+        have_pubs = {c["researcher_id"] for c in counts}
+        violators = [
+            {"id": r["id"], "name": f"{r['first_name']} {r['last_name']}"}
+            for r in rows if r["id"] not in have_pubs
+        ]
+        assert not violators, (
+            "directory returns researchers with zero publications (issue #147):\n"
+            + fmt_violations(violators)
+        )
+
+    def test_no_initial_only_names_in_directory(self):
+        rows, _ = self._directory_rows()
+        violators = [
+            {"id": r["id"], "first_name": r["first_name"], "last_name": r["last_name"]}
+            for r in rows
+            if len((r["first_name"] or "").strip()) <= 2 or len((r["last_name"] or "").strip()) <= 2
+        ]
+        assert not violators, (
+            "directory returns initial-only/abbreviated names:\n" + fmt_violations(violators)
+        )
+
+
+class TestResearcherFieldQuality:
+    """Field-level sanity on the researchers table itself."""
+
+    # Issue #150 measured ~18% NULL; the placeholder UI tolerates NULLs but a
+    # spike means extraction broke.
+    MAX_NULL_AFFILIATION_RATE = 0.35
+
+    def test_null_affiliation_rate_below_threshold(self, db):
+        row = db.fetch_one(
+            """
+            SELECT COUNT(*) AS total,
+                   SUM(affiliation IS NULL AND position IS NULL) AS no_affil
+            FROM researchers r
+            WHERE EXISTS (SELECT 1 FROM authorship a WHERE a.researcher_id = r.id)
+              AND EXISTS (SELECT 1 FROM researcher_urls ru WHERE ru.researcher_id = r.id)
+            """
+        )
+        total, no_affil = row["total"], int(row["no_affil"] or 0)
+        if total == 0:
+            return
+        rate = no_affil / total
+        assert rate <= self.MAX_NULL_AFFILIATION_RATE, (
+            f"{no_affil}/{total} tracked researchers ({rate:.0%}) have neither position "
+            f"nor affiliation — threshold {self.MAX_NULL_AFFILIATION_RATE:.0%} (issue #150)"
+        )
+
+    def test_no_mojibake_in_researcher_names(self, db):
+        """Bare 'Ã' is legitimate (SÃO); only 'Ã'+symbol bigrams are mojibake."""
+        rows = db.fetch_all(
+            f"""
+            SELECT id, first_name, last_name FROM researchers
+            WHERE {mojibake_condition('first_name')} OR {mojibake_condition('last_name')}
+            LIMIT 50
+            """
+        )
+        assert not rows, "researchers with mojibake names:\n" + fmt_violations(rows)
+
+    def test_no_blank_names(self, db):
+        rows = db.fetch_all(
+            """
+            SELECT id, first_name, last_name FROM researchers
+            WHERE TRIM(COALESCE(last_name, '')) = ''
+            LIMIT 50
+            """
+        )
+        assert not rows, "researchers with blank last names:\n" + fmt_violations(rows)
+
+
+class TestActiveUrlHealth:
+    """URL lifecycle invariants (PR #137 auto-deactivation)."""
+
+    def test_deactivated_urls_have_reason(self, db):
+        rows = db.fetch_all(
+            """
+            SELECT id, url, deactivated_at FROM researcher_urls
+            WHERE is_active = FALSE AND deactivated_at IS NOT NULL
+              AND deactivation_reason IS NULL
+            LIMIT 50
+            """
+        )
+        assert not rows, "deactivated URLs missing a reason:\n" + fmt_violations(rows)
+
+    def test_active_urls_have_no_deactivation_timestamp(self, db):
+        rows = db.fetch_all(
+            """
+            SELECT id, url, deactivated_at, deactivation_reason FROM researcher_urls
+            WHERE is_active = TRUE AND deactivated_at IS NOT NULL
+            LIMIT 50
+            """
+        )
+        assert not rows, "active URLs carrying deactivation state:\n" + fmt_violations(rows)

--- a/tests_data_quality/test_schema_integrity.py
+++ b/tests_data_quality/test_schema_integrity.py
@@ -1,0 +1,61 @@
+"""Schema-level safety nets that have silently failed before.
+
+PR #158 discovered the feed_events snapshot-guard trigger had NEVER existed
+in production: the migration failed on every startup with MySQL error 1419
+(app user lacks SUPER with binlog enabled) and only logged a warning. A test
+asserting the trigger exists would have caught months of missing protection.
+"""
+from conftest import fmt_violations
+
+
+class TestSnapshotGuardTrigger:
+    def test_feed_events_snapshot_guard_trigger_exists(self, db):
+        rows = db.fetch_all("SHOW TRIGGERS LIKE 'feed_events'")
+        names = {r.get("Trigger") for r in rows}
+        assert "trg_feed_events_snapshot_guard" in names, (
+            "trg_feed_events_snapshot_guard is missing — the DB-level new_paper "
+            "guard does not exist (MySQL error 1419? see PR #158: the container "
+            "needs --log-bin-trust-function-creators=1). Triggers present: "
+            f"{sorted(n for n in names if n)}"
+        )
+
+
+class TestExpectedTablesExist:
+    """Catches half-applied migrations: every table the code queries must exist."""
+
+    EXPECTED = [
+        "researchers", "researcher_urls", "papers", "paper_snapshots",
+        "html_content", "html_snapshots", "authorship", "feed_events",
+        "paper_links", "openalex_coauthors", "batch_jobs", "llm_usage",
+        "scrape_log", "researcher_snapshots",
+    ]
+
+    def test_all_expected_tables_exist(self, db):
+        rows = db.fetch_all("SHOW TABLES")
+        existing = {list(r.values())[0] for r in rows}
+        missing = [t for t in self.EXPECTED if t not in existing]
+        assert not missing, f"missing tables (migrations not applied?): {missing}"
+
+
+class TestHtmlContentConsistency:
+    """html_content drives the extraction queue; inconsistent rows stall it."""
+
+    def test_extracted_hash_implies_extracted_at(self, db):
+        rows = db.fetch_all(
+            """
+            SELECT id, url_id, extracted_hash, extracted_at FROM html_content
+            WHERE extracted_hash IS NOT NULL AND extracted_at IS NULL
+            LIMIT 50
+            """
+        )
+        assert not rows, "html_content rows extracted without timestamp:\n" + fmt_violations(rows)
+
+    def test_no_content_hash_without_content(self, db):
+        rows = db.fetch_all(
+            """
+            SELECT id, url_id, content_hash FROM html_content
+            WHERE content_hash IS NOT NULL AND (content IS NULL OR content = '')
+            LIMIT 50
+            """
+        )
+        assert not rows, "html_content rows with hash but no content:\n" + fmt_violations(rows)


### PR DESCRIPTION
## Summary
- **tests_data_quality/** (`make check-data`): invariant checks against the real DB — feed event guards (baseline, regressions, title-in-prior-snapshot), paper fields (years, titles, status denormalization), researcher directory guards, schema integrity (snapshot-guard trigger, expected tables, empty-content hashes). Failures are bad rows, not code bugs. Verified against a fresh prod mirror: 22/29 pass; the 7 failures are real data debt.
- **172 new unit tests** (status progression, title cleaning, search guards, feed event guard combinations, AffiliationLine/PublicationCard null handling), aligned with the post-#158 normalized matching contract.
- **`make sync-prod`** (`scripts/sync_prod_db.sh`): one-command local refresh from the latest Lightsail backup — downloads + verifies BEFORE recreating the volume, refuses truncated dumps, applies migrations.
- **`scripts/backup.sh` hardening**: dump to `.partial`, verify the `-- Dump completed` trailer, then promote; `--single-transaction --quick`; documents the working cron line. (The June 1 prod "backup" was silently truncated — no researchers/papers — and the 3am cron had never run due to an unwritable log redirect.)
- **`html_fetcher` fix**: unchanged-hash path now backfills missing `content` — 4,536 of 8,883 queued prod URLs (51%) were permanently stuck in a `no_content` extraction loop after the May metadata-only restore. The fleet self-heals on the next fetch cycle.

## Test Plan
- [x] `pytest` — 1053 passed (worktree, post-merge of all changes)
- [x] Frontend jest — 127 passed
- [x] `make check-data` against a verified June 11 prod mirror — 22/29, failures triaged as real data debt
- [ ] After deploy: fetch cycle backfills NULL-content rows (watch `test_no_content_hash_without_content` count drop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)