### PR TITLE
fix: keep advisory-lock connections alive past MySQL wait_timeout

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -21,12 +21,19 @@ _lock_conn = None  # connection holding the advisory lock for the duration of a 
 _scheduler = None
 _scheduler_lock_conn = None  # connection holding the advisory lock for the scheduler singleton
 
+# Lock connections sit idle while the lock is held (nothing ever queries on
+# them), so MySQL's default wait_timeout (8h) would kill them mid-scrape — the
+# lock silently drops, the zombie cleanup falsely fails the live scrape row,
+# and concurrent-scrape protection vanishes. A full scrape takes ~12h.
+_LOCK_CONN_WAIT_TIMEOUT = 7 * 24 * 3600  # 7 days
+
 
 def _acquire_db_lock() -> "mysql.connector.connection.MySQLConnection | None":
     """Try to acquire a MySQL advisory lock. Returns the connection if acquired, None otherwise."""
     try:
         conn = mysql.connector.connect(**db_config)
         cursor = conn.cursor()
+        cursor.execute("SET SESSION wait_timeout = %s", (_LOCK_CONN_WAIT_TIMEOUT,))
         cursor.execute("SELECT GET_LOCK(%s, 0)", (_LOCK_NAME,))
         result = cursor.fetchone()
         cursor.close()
@@ -472,6 +479,7 @@ def start_scheduler() -> None:
     try:
         conn = mysql.connector.connect(**db_config)
         cursor = conn.cursor()
+        cursor.execute("SET SESSION wait_timeout = %s", (_LOCK_CONN_WAIT_TIMEOUT,))
         cursor.execute("SELECT GET_LOCK(%s, 0)", (_SCHEDULER_LOCK_NAME,))
         result = cursor.fetchone()
         cursor.close()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -122,6 +122,30 @@ class TestLockAlreadyHeld:
 
 
 # ---------------------------------------------------------------------------
+# 2b. Lock connection keepalive
+# ---------------------------------------------------------------------------
+
+class TestLockConnectionKeepalive:
+    """The lock connection idles while held — it must outlive MySQL's default
+    8h wait_timeout or the lock drops mid-scrape and the zombie cleanup
+    falsely fails the live scrape row."""
+
+    @patch("scheduler.mysql.connector.connect")
+    def test_acquire_raises_session_wait_timeout(self, mock_connect):
+        cursor = mock_connect.return_value.cursor.return_value
+        cursor.fetchone.return_value = (1,)
+
+        conn = scheduler._acquire_db_lock()
+
+        assert conn is mock_connect.return_value
+        executed = [c.args[0] for c in cursor.execute.call_args_list]
+        assert any("wait_timeout" in q for q in executed)
+        # keepalive must be set before the lock is taken
+        assert "wait_timeout" in executed[0]
+        assert "GET_LOCK" in executed[1]
+
+
+# ---------------------------------------------------------------------------
 # 3. Error propagation — log updated to "failed"
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Observed in prod after #157 deployed: scrape_log row 63 was swept as a zombie at **exactly start + 8h00m00s** while the scrape was still actively fetching (18,680/27,314 URLs done).

The advisory-lock connections (scrape lock and scheduler-singleton lock) sit completely idle while the lock is held — nothing ever executes on them. MySQL's default `wait_timeout` (8h) kills idle connections, which silently releases the lock. A full scrape takes ~12h, so every full scrape would:

1. lose concurrent-scrape protection at the 8h mark, and
2. get falsely marked `failed` by the lock-aware zombie cleanup (which correctly treats "running row + no lock holder" as dead).

## Fix

Set `SET SESSION wait_timeout = 604800` (7 days) on both lock connections immediately after connecting, before `GET_LOCK`. Added a regression test asserting the keepalive is applied before the lock is taken.

## Testing

- New test: `TestLockConnectionKeepalive` verifies ordering (wait_timeout → GET_LOCK)
- Python suite runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)