### PR TITLE
fix: remove unused variable failing lint on main

### DIFF
--- a/app/src/components/__tests__/PublicationCard.edge-cases.test.tsx
+++ b/app/src/components/__tests__/PublicationCard.edge-cases.test.tsx
@@ -72,7 +72,7 @@ describe("PublicationCard with null fields", () => {
   });
 
   it("does not render status pill when status is null", () => {
-    const { container } = render(<PublicationCard publication={basePublication} />);
+    render(<PublicationCard publication={basePublication} />);
     expect(screen.queryByText("Working Paper")).not.toBeInTheDocument();
     expect(screen.queryByText("Published")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
One-line fix: `container` was destructured but unused in `PublicationCard.edge-cases.test.tsx`, failing `@typescript-eslint/no-unused-vars` during `next build` — which blocks the Frontend check and Vercel deployment for every open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)