### PR TITLE
fix: add diff_extraction to llm_usage.call_type ENUM

### DIFF
--- a/database/schema.py
+++ b/database/schema.py
@@ -271,7 +271,7 @@ _TABLE_DEFINITIONS = {
         CREATE TABLE IF NOT EXISTS llm_usage (
             id INT AUTO_INCREMENT PRIMARY KEY,
             called_at DATETIME NOT NULL,
-            call_type ENUM('publication_extraction','description_extraction','researcher_disambiguation','jel_classification') NOT NULL,
+            call_type ENUM('publication_extraction','description_extraction','researcher_disambiguation','jel_classification','diff_extraction') NOT NULL,
             model VARCHAR(100) NOT NULL,
             prompt_tokens INT NOT NULL DEFAULT 0,
             completion_tokens INT NOT NULL DEFAULT 0,
@@ -472,12 +472,16 @@ def create_tables() -> None:
                         except Exception as e:
                             logging.warning("Migration: utf8mb4 for %s: %s", tbl, e)
 
-                    # Add jel_classification to llm_usage.call_type ENUM
+                    # Extend llm_usage.call_type ENUM (jel_classification, diff_extraction).
+                    # Without diff_extraction, every diff-path usage INSERT fails with
+                    # MySQL 1265 and is silently dropped by log_llm_usage (seen in prod
+                    # 2026-06-12: ~350 untracked calls overnight)
                     try:
                         cursor.execute(
                             "ALTER TABLE llm_usage MODIFY COLUMN call_type "
                             "ENUM('publication_extraction','description_extraction',"
-                            "'researcher_disambiguation','jel_classification') NOT NULL"
+                            "'researcher_disambiguation','jel_classification',"
+                            "'diff_extraction') NOT NULL"
                         )
                         conn.commit()
                     except Exception as e:

--- a/tests_data_quality/test_schema_integrity.py
+++ b/tests_data_quality/test_schema_integrity.py
@@ -37,6 +37,37 @@ class TestExpectedTablesExist:
         assert not missing, f"missing tables (migrations not applied?): {missing}"
 
 
+class TestLlmUsageCallTypeEnum:
+    """Every call_type the code logs must exist in the DB enum.
+
+    log_llm_usage silences INSERT failures, so a call_type missing from the
+    ENUM drops usage rows invisibly (2026-06-12: every diff_extraction call
+    failed with MySQL 1265 — ~350 untracked calls in one night).
+    """
+
+    # Keep in sync with log_llm_usage call sites (grep: log_llm_usage\()
+    USED_CALL_TYPES = {
+        "publication_extraction", "description_extraction",
+        "researcher_disambiguation", "jel_classification", "diff_extraction",
+    }
+
+    def test_enum_covers_all_call_types_used_in_code(self, db):
+        row = db.fetch_one(
+            """
+            SELECT COLUMN_TYPE FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'llm_usage'
+              AND COLUMN_NAME = 'call_type'
+            """
+        )
+        assert row, "llm_usage.call_type column not found"
+        enum_def = row["COLUMN_TYPE"]
+        missing = [t for t in self.USED_CALL_TYPES if f"'{t}'" not in enum_def]
+        assert not missing, (
+            f"call_type values used in code but missing from ENUM {enum_def}: "
+            f"{missing} — their llm_usage INSERTs fail silently (error 1265)"
+        )
+
+
 class TestHtmlContentConsistency:
     """html_content drives the extraction queue; inconsistent rows stall it."""
 


### PR DESCRIPTION
## Summary
- PR #159 introduced the `diff_extraction` call type without extending the `llm_usage.call_type` ENUM — every diff-path usage INSERT fails with MySQL error 1265 and is silently dropped by `log_llm_usage` (~350 untracked calls on the first night; extractions themselves unaffected)
- Extends the ENUM in both `CREATE TABLE` and the idempotent startup migration
- Adds a data-quality guard (`make check-data`) asserting every call_type used in code exists in the DB enum — the unit tests mock `log_llm_usage`, so only a real-DB check catches this drift

## Test plan
- [x] 1093 unit tests pass
- [ ] Deploy: migration runs at API startup; verify `diff_extraction` rows appear in `llm_usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)