### PR TITLE
fix: absorb title-hash collision before rename UPDATE

### DIFF
--- a/paper_saver.py
+++ b/paper_saver.py
@@ -204,10 +204,10 @@ class PaperSaver:
         with Database.get_connection() as conn:
             cursor = conn.cursor(buffered=True)
             try:
-                cursor.execute(
-                    "UPDATE papers SET title = %s, title_hash = %s WHERE id = %s",
-                    (new_title, new_hash, paper_id),
-                )
+                # A paper with the target title may already exist (typically
+                # saved as "new" earlier in the same run). It must be absorbed
+                # BEFORE the title UPDATE — updating first violates
+                # uq_title_hash and crashed the extraction worker (#177).
                 cursor.execute(
                     "SELECT id FROM papers WHERE title_hash = %s AND id != %s",
                     (new_hash, paper_id),
@@ -215,12 +215,25 @@ class PaperSaver:
                 dup = cursor.fetchone()
                 if dup:
                     dup_id = dup[0]
-                    cursor.execute(
-                        "UPDATE IGNORE paper_urls SET paper_id = %s WHERE paper_id = %s",
-                        (paper_id, dup_id),
-                    )
+                    # Reassign children to the surviving paper; rows that would
+                    # violate a UNIQUE constraint are skipped (IGNORE) and
+                    # cleaned up by ON DELETE CASCADE. feed_events are deleted
+                    # instead — reassigning them would give the survivor a
+                    # duplicate new_paper event.
+                    from paper_merge import _CHILD_TABLES
+                    for table, col in _CHILD_TABLES:
+                        if table == 'feed_events':
+                            continue
+                        cursor.execute(
+                            f"UPDATE IGNORE `{table}` SET `{col}` = %s WHERE `{col}` = %s",
+                            (paper_id, dup_id),
+                        )
                     cursor.execute("DELETE FROM feed_events WHERE paper_id = %s", (dup_id,))
                     cursor.execute("DELETE FROM papers WHERE id = %s", (dup_id,))
+                cursor.execute(
+                    "UPDATE papers SET title = %s, title_hash = %s WHERE id = %s",
+                    (new_title, new_hash, paper_id),
+                )
                 conn.commit()
             except Exception as e:
                 conn.rollback()

--- a/tests/test_paper_saver.py
+++ b/tests/test_paper_saver.py
@@ -194,3 +194,60 @@ class TestAuthorLookupCache:
 
         PaperSaver.save_publications("http://example.com", pubs)
         assert mock_rid.call_count == 2
+
+
+class TestApplyTitleRenameCollision:
+    """apply_title_rename must absorb an existing paper with the target
+    title_hash BEFORE updating the title — updating first violates
+    uq_title_hash and crashes the extraction worker (#177)."""
+
+    def _run(self, dup_id=None):
+        """Run apply_title_rename with a mocked connection; return executed SQL list."""
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (dup_id,) if dup_id else None
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        with (
+            patch("paper_saver.Database.get_connection", return_value=conn),
+            patch("paper_saver.Database.append_paper_snapshot"),
+            patch("paper_saver.Database.compute_title_hash", return_value="newhash"),
+        ):
+            PaperSaver.apply_title_rename(
+                1, "Old Title", "New Title",
+                {"status": "working_paper"}, "http://example.com",
+            )
+        return [str(c[0][0]) for c in cursor.execute.call_args_list], conn
+
+    def test_collision_absorbed_before_title_update(self):
+        sqls, _ = self._run(dup_id=77)
+        update_idx = next(i for i, s in enumerate(sqls) if "UPDATE papers SET title" in s)
+        delete_idx = next(i for i, s in enumerate(sqls) if "DELETE FROM papers" in s)
+        assert delete_idx < update_idx, (
+            "duplicate paper must be removed BEFORE the title UPDATE, "
+            f"or the UPDATE violates uq_title_hash; order was: {sqls}"
+        )
+
+    def test_collision_moves_authorship_to_survivor(self):
+        sqls, _ = self._run(dup_id=77)
+        assert any("authorship" in s and "UPDATE IGNORE" in s for s in sqls), (
+            "dup paper's authorship rows must be reassigned, not dropped"
+        )
+
+    def test_collision_moves_links_and_snapshots(self):
+        sqls, _ = self._run(dup_id=77)
+        assert any("paper_links" in s for s in sqls)
+        assert any("paper_snapshots" in s for s in sqls)
+
+    def test_collision_deletes_dup_feed_events(self):
+        """Dup's feed events are deleted (not reassigned) to avoid duplicate
+        new_paper events on the surviving paper."""
+        sqls, _ = self._run(dup_id=77)
+        assert any("DELETE FROM feed_events" in s for s in sqls)
+
+    def test_no_collision_single_update_no_deletes(self):
+        sqls, conn = self._run(dup_id=None)
+        assert any("UPDATE papers SET title" in s for s in sqls)
+        assert not any("DELETE FROM papers" in s for s in sqls)
+        conn.commit.assert_called_once()


### PR DESCRIPTION
## Summary
- `apply_title_rename` ran `UPDATE papers SET title...` **before** checking whether another paper already holds the target `title_hash` — when the rename target already existed (typically saved as "new" earlier in the same run), the UPDATE violated `uq_title_hash` (MySQL 1062)
- Via the diff-extraction path (`extraction._apply_title_change`) the IntegrityError reached the extraction worker unguarded, burning the URL's retry budget (poison-pill after 3 attempts) — seen live on prod 2026-06-12 (philippesolal, url id=2534)
- Fix: resolve the collision first — reassign the duplicate's children to the survivor (reusing `paper_merge._CHILD_TABLES`; authorship/links/snapshots/urls/coauthors/topics), delete its feed events (reassigning would duplicate `new_paper` events), delete the duplicate row, **then** update the title

Closes #177

## Test Plan
- [x] 5 new tests: statement order (absorb-before-update), authorship/links/snapshots reassignment, feed-event deletion, no-collision path unchanged
- [x] Full suite: 1098 passed
- [ ] After deploy: no more 1062 worker errors; url id=2534 extracts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)