### PR TITLE
test: expand data-quality suite — 24 new invariant checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ make discover-domains     # Scan HTML for untrusted domains with paper-like link
 # Testing & validation
 make check                # Full suite: env check → pytest → tsc → jest
 make check-data           # Data-quality invariants against the real DB (tests_data_quality/) — failures are bad rows, not code bugs
+make check-data-live      # check-data + pipeline-liveness checks (scrape freshness, worker activity) — run on the server; meaningless on a synced mirror
 poetry run pytest                        # All Python tests
 poetry run pytest tests/test_api_publications.py  # Single test file
 poetry run pytest -k test_name           # Single test by name

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ check:
 check-data:  ## Data-quality invariant checks against the real DB (.env); fails on bad rows
 	poetry run pytest tests_data_quality -v
 
+check-data-live:  ## check-data + pipeline-liveness checks (run on the server against the live DB)
+	DATA_QUALITY_LIVE=1 poetry run pytest tests_data_quality -v
+
 sync-prod:  ## DESTRUCTIVE: replace local DB with latest prod backup (scp + fresh volume + migrations)
 	./scripts/sync_prod_db.sh
 

--- a/tests_data_quality/test_feed_event_quality.py
+++ b/tests_data_quality/test_feed_event_quality.py
@@ -182,3 +182,44 @@ class TestRecentNewPaperEventsAgainstSnapshots:
             f"{len(bogus)}/{len(events)} recent new_paper events have titles that were "
             "already on the page in the prior snapshot (bogus events):\n" + fmt_violations(bogus)
         )
+
+
+class TestEventsFromDeadUrls:
+    """Events created after their source URL was deactivated mean a zombie
+    pipeline path kept writing (PR #137 lifecycle violation)."""
+
+    def test_no_events_after_url_deactivation(self, db):
+        rows = db.fetch_all(
+            """SELECT fe.id, fe.event_type, fe.created_at, ru.deactivated_at, ru.url
+               FROM feed_events fe
+               JOIN papers p ON p.id = fe.paper_id
+               JOIN researcher_urls ru ON ru.url = p.source_url
+               WHERE ru.is_active = FALSE AND ru.deactivated_at IS NOT NULL
+                 AND fe.created_at > ru.deactivated_at + INTERVAL 1 HOUR
+               LIMIT 50"""
+        )
+        assert not rows, "events created after URL deactivation:\n" + fmt_violations(rows)
+
+
+class TestEventEvidence:
+    """Events must be backed by observable history."""
+
+    def test_status_change_requires_snapshots(self, db):
+        """A status change can only be OBSERVED between two extractions —
+        a paper with zero snapshots cannot have one."""
+        rows = db.fetch_all(
+            """SELECT fe.id, fe.paper_id, fe.old_status, fe.new_status
+               FROM feed_events fe
+               WHERE fe.event_type = 'status_change'
+                 AND NOT EXISTS (SELECT 1 FROM paper_snapshots ps WHERE ps.paper_id = fe.paper_id)
+               LIMIT 50"""
+        )
+        assert not rows, "status_change events with zero snapshots:\n" + fmt_violations(rows)
+
+    def test_no_noop_title_changes(self, db):
+        rows = db.fetch_all(
+            """SELECT id, paper_id, old_title FROM feed_events
+               WHERE event_type = 'title_change' AND old_title = new_title
+               LIMIT 50"""
+        )
+        assert not rows, "no-op title_change events:\n" + fmt_violations(rows)

--- a/tests_data_quality/test_paper_quality.py
+++ b/tests_data_quality/test_paper_quality.py
@@ -136,3 +136,179 @@ class TestPaperRelationalIntegrity:
             """
         )
         assert not rows, "papers with no authors (unreachable from any researcher):\n" + fmt_violations(rows)
+
+
+class TestTitleHashIntegrity:
+    """papers.title_hash must equal compute_title_hash(title) for every row.
+
+    Drift means a writer updated one without the other (the #177 rename bug
+    family) — dedup silently breaks for that paper from then on.
+    """
+
+    def test_title_hash_matches_title(self, db):
+        from database.papers import compute_title_hash
+
+        rows = db.fetch_all("SELECT id, title, title_hash FROM papers WHERE title IS NOT NULL")
+        bad = [
+            {"id": r["id"], "title": (r["title"] or "")[:60]}
+            for r in rows
+            if r["title_hash"] != compute_title_hash(r["title"])
+        ]
+        assert not bad, f"papers with stale title_hash ({len(bad)} total):\n" + fmt_violations(bad)
+
+
+class TestNearDuplicatePapers:
+    """Two papers by the same researcher with near-identical titles are the
+    title-variant duplicates of issue #107 / the #177 collision family —
+    merge_duplicate_papers only catches DOI/OpenAlex or 2+-shared-author cases.
+    """
+
+    SIMILARITY = 0.92
+
+    def test_no_near_duplicate_titles_per_researcher(self, db):
+        from difflib import SequenceMatcher
+        from database.papers import normalize_title
+
+        rows = db.fetch_all(
+            """SELECT a.researcher_id, p.id, p.title
+               FROM papers p JOIN authorship a ON a.publication_id = p.id
+               WHERE p.title IS NOT NULL"""
+        )
+        by_researcher: dict[int, list[tuple[int, str, str]]] = {}
+        for r in rows:
+            norm = normalize_title(r["title"])
+            if norm:
+                by_researcher.setdefault(r["researcher_id"], []).append((r["id"], r["title"], norm))
+
+        seen_pairs = set()
+        dupes = []
+        for rid, papers in by_researcher.items():
+            if len(papers) < 2:
+                continue
+            papers.sort(key=lambda x: x[2])
+            for (id1, t1, n1), (id2, t2, n2) in zip(papers, papers[1:]):
+                pair = tuple(sorted((id1, id2)))
+                if id1 == id2 or pair in seen_pairs or n1[:20] != n2[:20]:
+                    continue
+                if SequenceMatcher(None, n1.split(), n2.split()).ratio() >= self.SIMILARITY:
+                    seen_pairs.add(pair)
+                    dupes.append({"paper_ids": pair, "t1": t1[:55], "t2": t2[:55]})
+        assert not dupes, (
+            f"near-duplicate paper titles within a researcher ({len(dupes)} pairs):\n"
+            + fmt_violations(dupes)
+        )
+
+
+class TestExtractionArtifacts:
+    """LLM/HTML residue that should never survive clean_title/save paths."""
+
+    def test_no_raw_html_entities_in_titles(self, db):
+        rows = db.fetch_all(
+            """SELECT id, title FROM papers
+               WHERE title LIKE '%&amp;%' OR title LIKE '%&#%'
+                  OR title LIKE '%&quot;%' OR title LIKE '%&nbsp;%'
+               LIMIT 50"""
+        )
+        assert not rows, "titles with raw HTML entities:\n" + fmt_violations(rows)
+
+    def test_no_html_tags_in_titles(self, db):
+        rows = db.fetch_all(
+            """SELECT id, title FROM papers
+               WHERE title LIKE '%</%' OR title LIKE '%<em>%' OR title LIKE '%<i>%'
+                  OR title LIKE '%<span%' OR title LIKE '%<br%'
+               LIMIT 50"""
+        )
+        assert not rows, "titles with HTML tags:\n" + fmt_violations(rows)
+
+    def test_no_truncated_titles(self, db):
+        """Trailing ellipsis/comma/dash usually means the LLM hit a token cliff."""
+        rows = db.fetch_all(
+            r"""SELECT id, title FROM papers
+                WHERE title REGEXP '(\\.\\.\\.|…|,|;)$'
+                LIMIT 50"""
+        )
+        assert not rows, "titles ending in truncation markers:\n" + fmt_violations(rows)
+
+    def test_no_status_words_as_venue(self, db):
+        """A venue that is ONLY a status phrase belongs in papers.status."""
+        rows = db.fetch_all(
+            """SELECT id, venue, status FROM papers
+               WHERE LOWER(TRIM(venue)) IN
+                 ('working paper', 'draft', 'under review', 'submitted',
+                  'r&r', 'revise and resubmit', 'reject and resubmit',
+                  'work in progress', 'job market paper', 'jmp')
+               LIMIT 50"""
+        )
+        assert not rows, "status phrases stored as venue:\n" + fmt_violations(rows)
+
+    def test_no_mojibake_in_venue_or_abstract(self, db):
+        rows = db.fetch_all(
+            f"""SELECT id, LEFT(COALESCE(venue,''), 40) AS venue,
+                       LEFT(COALESCE(abstract,''), 60) AS abstract_head
+                FROM papers
+                WHERE {mojibake_condition('venue')} OR {mojibake_condition('abstract')}
+                LIMIT 50"""
+        )
+        assert not rows, "mojibake in venue/abstract:\n" + fmt_violations(rows)
+
+    def test_no_junk_abstracts(self, db):
+        """Non-null abstracts under 40 chars are extraction noise, not abstracts."""
+        rows = db.fetch_all(
+            """SELECT id, abstract FROM papers
+               WHERE abstract IS NOT NULL AND TRIM(abstract) != ''
+                 AND CHAR_LENGTH(abstract) < 40
+               LIMIT 50"""
+        )
+        assert not rows, "junk abstracts (<40 chars):\n" + fmt_violations(rows)
+
+
+class TestDraftUrlQuality:
+    def test_draft_urls_use_http_scheme(self, db):
+        rows = db.fetch_all(
+            """SELECT id, draft_url FROM papers
+               WHERE draft_url IS NOT NULL
+                 AND draft_url NOT LIKE 'http://%' AND draft_url NOT LIKE 'https://%'
+               LIMIT 50"""
+        )
+        assert not rows, "draft_urls with bad scheme:\n" + fmt_violations(rows)
+
+    def test_draft_url_is_not_source_url(self, db):
+        """draft_url pointing back at the listing page is an extraction artifact."""
+        rows = db.fetch_all(
+            """SELECT id, draft_url FROM papers
+               WHERE draft_url IS NOT NULL AND draft_url = source_url
+               LIMIT 50"""
+        )
+        assert not rows, "draft_url equals source_url:\n" + fmt_violations(rows)
+
+
+class TestDiscoveredAtSanity:
+    def test_no_future_discovered_at(self, db):
+        rows = db.fetch_all(
+            "SELECT id, discovered_at FROM papers WHERE discovered_at > NOW() + INTERVAL 1 DAY LIMIT 50"
+        )
+        assert not rows, "papers discovered in the future:\n" + fmt_violations(rows)
+
+    def test_no_pre_epoch_discovered_at(self, db):
+        from conftest import PROJECT_EPOCH
+        rows = db.fetch_all(
+            f"SELECT id, discovered_at FROM papers WHERE discovered_at < '{PROJECT_EPOCH}' LIMIT 50"
+        )
+        assert not rows, "papers discovered before the project existed:\n" + fmt_violations(rows)
+
+
+class TestAuthorshipSanity:
+    """Extraction blow-ups create papers with absurd author lists."""
+
+    MAX_PLAUSIBLE_AUTHORS = 100
+
+    def test_no_papers_with_absurd_author_counts(self, db):
+        rows = db.fetch_all(
+            f"""SELECT p.id, LEFT(p.title, 50) AS title, COUNT(*) AS n_authors
+                FROM papers p JOIN authorship a ON a.publication_id = p.id
+                GROUP BY p.id, p.title
+                HAVING COUNT(*) > {self.MAX_PLAUSIBLE_AUTHORS}
+                ORDER BY n_authors DESC
+                LIMIT 50"""
+        )
+        assert not rows, "papers with implausibly many authors:\n" + fmt_violations(rows)

--- a/tests_data_quality/test_pipeline_health.py
+++ b/tests_data_quality/test_pipeline_health.py
@@ -1,0 +1,80 @@
+"""Pipeline liveness checks — only meaningful against the LIVE database.
+
+A synced mirror is frozen at dump time, so freshness assertions would always
+fail there. These tests skip unless DATA_QUALITY_LIVE=1 (run them on the
+server: `make check-data-live` inside /opt/econ-newsfeed).
+
+Each check maps to a real outage class:
+- 2026-06-10: extraction silently stalled for hours (fenced-JSON change)
+- 2026-06-11: backups had never run (cron) and nobody noticed
+- scrape_log zombie 'running' rows from mid-scrape process deaths
+"""
+import os
+
+import pytest
+
+from conftest import fmt_violations
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DATA_QUALITY_LIVE") != "1",
+    reason="pipeline-health checks need the live DB (set DATA_QUALITY_LIVE=1)",
+)
+
+
+class TestScrapePipelineFreshness:
+    def test_scrape_ran_recently(self, db):
+        """The scheduler should complete a scrape at least every 48h."""
+        row = db.fetch_one(
+            "SELECT MAX(started_at) AS last_start FROM scrape_log"
+        )
+        assert row and row["last_start"], "scrape_log is empty — scheduler never ran"
+        age = db.fetch_one(
+            "SELECT TIMESTAMPDIFF(HOUR, MAX(started_at), NOW()) AS hours FROM scrape_log"
+        )
+        assert age["hours"] is not None and age["hours"] <= 48, (
+            f"no scrape started in {age['hours']}h — scheduler dead?"
+        )
+
+    def test_no_stuck_running_scrapes(self, db):
+        """Startup cleanup marks zombies, but a live row >24h means a hang."""
+        rows = db.fetch_all(
+            """SELECT id, started_at FROM scrape_log
+               WHERE status = 'running' AND started_at < NOW() - INTERVAL 24 HOUR"""
+        )
+        assert not rows, "scrape runs stuck in 'running' >24h:\n" + fmt_violations(rows)
+
+
+class TestExtractionWorkerLiveness:
+    def test_worker_active_when_queue_nonempty(self, db):
+        """If extractable work exists (pending hash + stored content), the
+        worker must have made an LLM call within the last 6 hours — silence
+        here is how the 2026-06-10 stall went unnoticed."""
+        queue = db.fetch_one(
+            """SELECT COUNT(*) AS n
+               FROM html_content hc JOIN researcher_urls ru ON ru.id = hc.url_id
+               WHERE ru.is_active = TRUE
+                 AND hc.content IS NOT NULL AND hc.content != ''
+                 AND hc.content_hash IS NOT NULL
+                 AND (hc.extracted_hash IS NULL OR hc.extracted_hash != hc.content_hash)"""
+        )
+        if not queue or queue["n"] == 0:
+            return
+        last_call = db.fetch_one(
+            """SELECT TIMESTAMPDIFF(HOUR, MAX(called_at), NOW()) AS hours
+               FROM llm_usage WHERE call_type = 'publication_extraction'"""
+        )
+        assert last_call and last_call["hours"] is not None and last_call["hours"] <= 6, (
+            f"{queue['n']} URLs are extractable but the last extraction LLM call was "
+            f"{last_call['hours'] if last_call else 'never'}h ago — worker stalled?"
+        )
+
+
+class TestBatchJobHygiene:
+    def test_no_stale_pending_batches(self, db):
+        rows = db.fetch_all(
+            """SELECT id, openai_batch_id, status, created_at FROM batch_jobs
+               WHERE status IN ('submitted', 'validating', 'in_progress', 'finalizing')
+                 AND created_at < NOW() - INTERVAL 48 HOUR
+               LIMIT 20"""
+        )
+        assert not rows, "batch jobs stuck >48h:\n" + fmt_violations(rows)

--- a/tests_data_quality/test_researcher_quality.py
+++ b/tests_data_quality/test_researcher_quality.py
@@ -125,3 +125,91 @@ class TestActiveUrlHealth:
             """
         )
         assert not rows, "active URLs carrying deactivation state:\n" + fmt_violations(rows)
+
+
+class TestResearcherDuplicates:
+    """Disambiguation failures create twin researcher rows that split a
+    person's papers across two profiles."""
+
+    def test_no_shared_openalex_author_id(self, db):
+        rows = db.fetch_all(
+            """SELECT openalex_author_id, COUNT(*) AS n,
+                      GROUP_CONCAT(id ORDER BY id) AS researcher_ids
+               FROM researchers
+               WHERE openalex_author_id IS NOT NULL
+               GROUP BY openalex_author_id
+               HAVING COUNT(*) > 1
+               LIMIT 50"""
+        )
+        assert not rows, "openalex_author_id shared by multiple researchers:\n" + fmt_violations(rows)
+
+    def test_no_exact_name_duplicates_with_publications(self, db):
+        """Same (case-insensitive) full name on 2+ researchers who BOTH have
+        papers — almost always a split profile, not a namesake."""
+        rows = db.fetch_all(
+            """SELECT LOWER(first_name) AS fn, LOWER(last_name) AS ln,
+                      COUNT(*) AS n, GROUP_CONCAT(r.id ORDER BY r.id) AS ids
+               FROM researchers r
+               WHERE EXISTS (SELECT 1 FROM authorship a WHERE a.researcher_id = r.id)
+               GROUP BY LOWER(first_name), LOWER(last_name)
+               HAVING COUNT(*) > 1
+               LIMIT 50"""
+        )
+        assert not rows, "exact-name duplicate researchers with publications:\n" + fmt_violations(rows)
+
+
+class TestAffiliationFieldQuality:
+    def test_no_overlong_affiliations(self, db):
+        """Affiliations beyond 250 chars are usually a bio sentence stuffed
+        into the field by the LLM."""
+        rows = db.fetch_all(
+            """SELECT id, CHAR_LENGTH(affiliation) AS len, LEFT(affiliation, 70) AS head
+               FROM researchers
+               WHERE CHAR_LENGTH(affiliation) > 250
+               LIMIT 50"""
+        )
+        assert not rows, "overlong affiliations (bio leakage):\n" + fmt_violations(rows)
+
+    def test_affiliation_not_equal_position(self, db):
+        rows = db.fetch_all(
+            """SELECT id, position FROM researchers
+               WHERE affiliation IS NOT NULL AND position IS NOT NULL
+                 AND LOWER(TRIM(affiliation)) = LOWER(TRIM(position))
+               LIMIT 50"""
+        )
+        assert not rows, "affiliation duplicated into position:\n" + fmt_violations(rows)
+
+
+class TestUrlIntegrity:
+    """researcher_urls hygiene beyond the deactivation-state checks."""
+
+    def test_active_urls_below_failure_threshold(self, db):
+        """_URL_DEACTIVATION_THRESHOLD=3 — an active URL at/over it means the
+        auto-deactivation path was bypassed."""
+        rows = db.fetch_all(
+            """SELECT id, url, consecutive_failures FROM researcher_urls
+               WHERE is_active = TRUE AND consecutive_failures >= 3
+               LIMIT 50"""
+        )
+        assert not rows, "active URLs at/over the deactivation threshold:\n" + fmt_violations(rows)
+
+    def test_urls_use_http_scheme(self, db):
+        rows = db.fetch_all(
+            """SELECT id, url FROM researcher_urls
+               WHERE url NOT LIKE 'http://%' AND url NOT LIKE 'https://%'
+               LIMIT 50"""
+        )
+        assert not rows, "researcher URLs with bad scheme:\n" + fmt_violations(rows)
+
+    def test_no_url_shared_across_researchers(self, db):
+        """The same page tracked under two researchers double-extracts every
+        paper on it and mis-attributes page ownership."""
+        rows = db.fetch_all(
+            """SELECT url, COUNT(DISTINCT researcher_id) AS n,
+                      GROUP_CONCAT(DISTINCT researcher_id) AS researcher_ids
+               FROM researcher_urls
+               GROUP BY url
+               HAVING COUNT(DISTINCT researcher_id) > 1
+               LIMIT 50"""
+        )
+        assert not rows, "URLs tracked under multiple researchers:\n" + fmt_violations(rows)

--- a/tests_data_quality/test_schema_integrity.py
+++ b/tests_data_quality/test_schema_integrity.py
@@ -90,3 +90,33 @@ class TestHtmlContentConsistency:
             """
         )
         assert not rows, "html_content rows with hash but no content:\n" + fmt_violations(rows)
+
+
+class TestTimestampSanity:
+    def test_no_future_html_snapshots(self, db):
+        rows = db.fetch_all(
+            "SELECT id, url_id, snapshot_at FROM html_snapshots "
+            "WHERE snapshot_at > NOW() + INTERVAL 1 DAY LIMIT 50"
+        )
+        assert not rows, "future-dated html_snapshots:\n" + fmt_violations(rows)
+
+    def test_no_future_paper_snapshots(self, db):
+        rows = db.fetch_all(
+            "SELECT id, paper_id, scraped_at FROM paper_snapshots "
+            "WHERE scraped_at > NOW() + INTERVAL 1 DAY LIMIT 50"
+        )
+        assert not rows, "future-dated paper_snapshots:\n" + fmt_violations(rows)
+
+
+class TestSourceUrlTracking:
+    def test_papers_source_url_is_tracked(self, db):
+        """A paper whose source_url has no researcher_urls row came from a
+        page the system no longer knows — its feed-event guards (snapshot
+        baseline, title-in-prior-snapshot) can never run again."""
+        rows = db.fetch_all(
+            """SELECT p.id, p.source_url FROM papers p
+               WHERE p.source_url IS NOT NULL
+                 AND NOT EXISTS (SELECT 1 FROM researcher_urls ru WHERE ru.url = p.source_url)
+               LIMIT 50"""
+        )
+        assert not rows, "papers whose source_url is untracked:\n" + fmt_violations(rows)


### PR DESCRIPTION
## Summary
- Grows the data-quality suite from 29 to 53 checks + 4 live-only pipeline-health checks; every new check was triaged against the June 11 prod mirror so failures are verified true positives, not noise
- **New paper checks**: title_hash drift (#177 family), within-researcher near-duplicate titles (187 real pairs — the #107 title-variant class), HTML entities/tags in titles, truncated titles, status-phrases-as-venue, venue/abstract mojibake, junk abstracts (literal `'null'`, HAL boilerplate), draft_url self-links (50+), >100-author extraction blow-ups (one paper has 378)
- **New researcher checks**: shared `openalex_author_id` (50+ hard duplicate profiles), exact-name duplicates with publications (28 split profiles), malformed URL schemes, same URL tracked under multiple researchers (NY Fed dept page under 5 people — page-owner mis-attribution risk)
- **New feed-event/schema checks**: events after URL deactivation, status_change without snapshot evidence, no-op title_changes, future-dated snapshots, untracked source_urls
- **New `make check-data-live`** (gated `DATA_QUALITY_LIVE=1`): scrape freshness, stuck runs, extraction-worker liveness via `llm_usage` (would have caught the 2026-06-10 silent extraction stall), stale batch jobs — server-only since freshness is meaningless on a synced mirror
- Triage discipline applied: dropped a noisy check (trailing citation years), tuned thresholds (authors 25→100 for consortium papers, affiliations 150→250 for institution chains), deduped coauthor-repeated pairs

## Test Plan
- [x] Full unit suite: 1098 passed (data suite is outside `testpaths`, CI unaffected)
- [x] Expanded suite vs June 11 prod mirror: 37 passed / 19 failed — all 19 verified real (12 new finding classes + 7 known)
- [ ] Run `make check-data-live` on the server once for the pipeline-health checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)