### PR TITLE
fix: prevent scrape failures from worker recycling and idle lock timeout

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -16,4 +16,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "gunicorn backend.api:app --workers ${WEB_CONCURRENCY:-2} --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --log-level info --max-requests 1000 --max-requests-jitter 100 --preload"]
+CMD ["sh", "-c", "gunicorn backend.api:app --workers ${WEB_CONCURRENCY:-2} --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --log-level info --preload"]

--- a/backend/database/admin.py
+++ b/backend/database/admin.py
@@ -202,7 +202,7 @@ def _get_scrape_stats() -> dict:
     """Recent scrape history."""
     recent = fetch_all(
         """SELECT started_at, status, urls_checked, urls_changed,
-                  pubs_extracted, finished_at,
+                  pubs_extracted, finished_at, error_message,
                   COALESCE((SELECT SUM(total_tokens) FROM llm_usage
                             WHERE scrape_log_id = s.id), 0) AS tokens_used
            FROM scrape_log s ORDER BY id DESC LIMIT 30"""
@@ -226,6 +226,7 @@ def _get_scrape_stats() -> dict:
             "pubs_extracted": r["pubs_extracted"] or 0,
             "tokens_used": int(r["tokens_used"]),
             "duration_seconds": duration,
+            "error_message": r["error_message"],
         })
 
     totals = fetch_one(

--- a/backend/pipeline/scheduler.py
+++ b/backend/pipeline/scheduler.py
@@ -53,6 +53,22 @@ def _acquire_db_lock() -> "mysql.connector.connection.MySQLConnection | None":
         return None
 
 
+def _ping_lock_conn(conn: "mysql.connector.connection.MySQLConnection") -> None:
+    """Send a lightweight query on the lock connection to keep it alive.
+
+    The lock connection sits idle for the entire scrape. Despite SET SESSION
+    wait_timeout = 7 days, the connection dies at ~8h in production. A periodic
+    SELECT 1 resets the idle timer and keeps TCP alive.
+    """
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT 1")
+        cursor.fetchone()
+        cursor.close()
+    except Exception as e:
+        logger.warning("Lock connection ping failed: %s", e)
+
+
 def _release_db_lock(conn: "mysql.connector.connection.MySQLConnection") -> None:
     """Release the MySQL advisory lock and close the connection."""
     try:
@@ -227,7 +243,9 @@ def _validate_draft_urls() -> None:
     logger.info(f"Validating {len(unchecked)} unchecked draft URLs")
     start = time.time()
     validated = 0
-    for paper_id, draft_url in unchecked:
+    for row in unchecked:
+        paper_id = row['id']
+        draft_url = row['draft_url']
         if time.time() - start > _DRAFT_VALIDATION_BUDGET_SECONDS:
             logger.info(f"Draft URL validation time budget exceeded after {validated} URLs")
             break
@@ -316,6 +334,7 @@ def run_scrape_job() -> None:
 
                 if urls_checked % 10 == 0:
                     _with_db_retry(_update_progress, log_id, urls_checked=urls_checked, urls_changed=urls_changed)
+                    _ping_lock_conn(lock_conn)
 
             except _TRANSIENT_MYSQL_ERRORS as e:
                 logger.error("MySQL connection error fetching URL %s (id=%s) after retries: %s", url, url_id, e)

--- a/backend/pipeline/scheduler.py
+++ b/backend/pipeline/scheduler.py
@@ -32,7 +32,11 @@ _scheduler_lock_conn = None  # connection holding the advisory lock for the sche
 # lock silently drops, the zombie cleanup falsely fails the live scrape row,
 # and concurrent-scrape protection vanishes. A full scrape takes ~12h.
 _LOCK_CONN_WAIT_TIMEOUT = 7 * 24 * 3600  # 7 days
+_LOCK_KEEPALIVE_SECONDS = 1800  # ping idle lock connections every 30 min
 _MAX_SCRAPE_DURATION_HOURS = 18  # force-release lock if scrape exceeds this
+
+_keepalive_stop = threading.Event()
+_keepalive_thread = None
 
 
 def _acquire_db_lock() -> "mysql.connector.connection.MySQLConnection | None":
@@ -53,20 +57,22 @@ def _acquire_db_lock() -> "mysql.connector.connection.MySQLConnection | None":
         return None
 
 
-def _ping_lock_conn(conn: "mysql.connector.connection.MySQLConnection") -> None:
-    """Send a lightweight query on the lock connection to keep it alive.
+def _lock_keepalive_loop() -> None:
+    """Ping idle lock connections on a fixed wall-clock interval.
 
-    The lock connection sits idle for the entire scrape. Despite SET SESSION
-    wait_timeout = 7 days, the connection dies at ~8h in production. A periodic
-    SELECT 1 resets the idle timer and keeps TCP alive.
+    Both _lock_conn (scrape) and _scheduler_lock_conn sit idle for hours/days.
+    Despite SET SESSION wait_timeout = 7 days, connections die at ~8h in
+    production. A periodic conn.ping() resets the idle timer and keeps TCP alive.
+    Runs as a daemon thread started alongside the scheduler.
     """
-    try:
-        cursor = conn.cursor()
-        cursor.execute("SELECT 1")
-        cursor.fetchone()
-        cursor.close()
-    except Exception as e:
-        logger.warning("Lock connection ping failed: %s", e)
+    while not _keepalive_stop.wait(_LOCK_KEEPALIVE_SECONDS):
+        for name, conn in [("scrape", _lock_conn), ("scheduler", _scheduler_lock_conn)]:
+            if conn is None:
+                continue
+            try:
+                conn.ping(reconnect=False)
+            except Exception as e:
+                logger.warning("Lock keepalive ping failed (%s): %s", name, e)
 
 
 def _release_db_lock(conn: "mysql.connector.connection.MySQLConnection") -> None:
@@ -334,7 +340,6 @@ def run_scrape_job() -> None:
 
                 if urls_checked % 10 == 0:
                     _with_db_retry(_update_progress, log_id, urls_checked=urls_checked, urls_changed=urls_changed)
-                    _ping_lock_conn(lock_conn)
 
             except _TRANSIENT_MYSQL_ERRORS as e:
                 logger.error("MySQL connection error fetching URL %s (id=%s) after retries: %s", url, url_id, e)
@@ -372,6 +377,27 @@ def run_scrape_job() -> None:
         logger.error("Paper merge failed: %s: %s", type(e).__name__, e)
     merge_s = time.time() - t0
     logger.info(f"Paper merge: {merge_s:.1f}s")
+
+
+def _start_lock_keepalive() -> None:
+    global _keepalive_thread
+    if _keepalive_thread is not None and _keepalive_thread.is_alive():
+        return
+    _keepalive_stop.clear()
+    _keepalive_thread = threading.Thread(
+        target=_lock_keepalive_loop, name="lock-keepalive", daemon=True,
+    )
+    _keepalive_thread.start()
+    logger.info("Lock keepalive thread started (interval=%ds)", _LOCK_KEEPALIVE_SECONDS)
+
+
+def _stop_lock_keepalive() -> None:
+    global _keepalive_thread
+    if _keepalive_thread is None:
+        return
+    _keepalive_stop.set()
+    _keepalive_thread.join(timeout=5)
+    _keepalive_thread = None
 
 
 def _handle_sigterm(signum: int, frame: object) -> None:
@@ -593,6 +619,8 @@ def start_scheduler() -> None:
     _scheduler.start()
     logger.info(f"Scheduler started: scraping every {SCRAPE_INTERVAL_HOURS} hours")
 
+    _start_lock_keepalive()
+
     if SCRAPE_ON_STARTUP:
         logger.info("SCRAPE_ON_STARTUP is true, triggering immediate scrape in background")
         threading.Thread(target=run_scrape_job, name="startup-scrape").start()
@@ -607,6 +635,7 @@ def start_scheduler() -> None:
 def shutdown_scheduler() -> None:
     """Shut down the scheduler gracefully, waiting for any running job to complete."""
     global _scheduler, _scheduler_lock_conn
+    _stop_lock_keepalive()
     stop_enrichment_worker()
     stop_extraction_worker()
     if _scheduler is not None:


### PR DESCRIPTION
## Summary
- **Remove `--max-requests 1000` from gunicorn** — with `WEB_CONCURRENCY=1`, worker recycling kills the single worker process, terminating the scrape daemon thread mid-run. This caused most of the variable-duration scrape failures (1h, 1h15m, 4h32m, etc.)
- **Add background keepalive thread for advisory lock connections** — both the scrape lock and scheduler lock connections sit idle for hours/days. A daemon thread pings them every 30 minutes via `conn.ping()`, preventing the ~8h timeout failures where the zombie cleanup falsely marks the scrape as failed. Covers both connections and is stall-immune (fires on wall-clock time, not gated on scrape loop progress)
- **Fix `_validate_draft_urls()` dict unpacking** — was iterating dict keys (`'id'`, `'draft_url'`) instead of values, silently breaking draft URL validation
- **Surface `error_message` in admin scrape stats** — failed scrapes now show their reason in the dashboard

## Test plan
- [x] All 1151 tests pass
- [ ] Deploy and monitor next scrape run completes successfully (takes ~8-12h to verify)
- [ ] Check admin dashboard shows `error_message` column for past failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)