### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+For a full architecture, command, and deployment reference see `CLAUDE.md`. This file only adds notes specific to running the project inside a Cursor Cloud agent VM.
+
+## Cursor Cloud specific instructions
+
+### Services & how to run them
+This is a monorepo with three services (details and commands in `CLAUDE.md`):
+- **MySQL 8** — local server (installed via apt, not Docker here). Data persists in the VM snapshot.
+- **Backend API (FastAPI/uvicorn)** — local dev runs on **:8001** (`make dev`), not :8000.
+- **Frontend (Next.js)** — runs on **:3000** (`make dev`), proxies `/api/*` to `API_INTERNAL_URL`.
+
+Standard commands live in the `Makefile` (`make dev`, `make seed`, `make check`, etc.) and `app/package.json`. Don't duplicate them; use them.
+
+### Startup caveats (non-obvious)
+- **MySQL is not auto-started on boot.** Run `sudo service mysql start` at the beginning of a session before seeding or starting the API (Docker is not used in this environment).
+- **Injected secrets override `.env`.** The VM injects `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `GOOGLE_API_KEY`, and `SCRAPE_API_KEY` as environment variables. `backend/config.py` calls `load_dotenv()` which does **not** override existing env vars, so the injected values win over anything in `.env`. The local MySQL has been provisioned with a user/database matching the injected `DB_USER`/`DB_PASSWORD`/`DB_NAME` so the app connects locally. `DB_HOST` is read from `.env` (`127.0.0.1`). If injected DB credentials ever change and auth fails, re-provision the local user:
+  ```bash
+  sudo mysql -e "CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    CREATE USER IF NOT EXISTS '${DB_USER}'@'127.0.0.1' IDENTIFIED BY '${DB_PASSWORD}';
+    CREATE USER IF NOT EXISTS '${DB_USER}'@'localhost' IDENTIFIED BY '${DB_PASSWORD}';
+    ALTER USER '${DB_USER}'@'127.0.0.1' IDENTIFIED BY '${DB_PASSWORD}';
+    ALTER USER '${DB_USER}'@'localhost' IDENTIFIED BY '${DB_PASSWORD}';
+    GRANT ALL PRIVILEGES ON *.* TO '${DB_USER}'@'127.0.0.1' WITH GRANT OPTION;
+    GRANT ALL PRIVILEGES ON *.* TO '${DB_USER}'@'localhost' WITH GRANT OPTION;
+    FLUSH PRIVILEGES;"
+  ```
+  Then `make seed` (idempotent) to create tables.
+- **tmux sessions must inherit the injected secrets.** A pre-existing tmux server may have been started before secrets were injected; new sessions then inherit that stale env and the API fails with `Access denied for user ...`. If that happens, run `tmux kill-server` and recreate the session from a fresh shell (which has the injected secrets).
+- **The injected `GOOGLE_API_KEY` is not guaranteed to be a valid Google AI Studio key.** The API/frontend serve existing DB data without the LLM, but the live extraction pipeline (`make extract` / `make scrape`) needs a valid key. Without one, `make fetch` still works (downloads HTML); only LLM extraction fails.
+
+### Testing caveat (non-obvious)
+- `tests/conftest.py` sets its own test env via `os.environ.setdefault(...)`, so the **injected secrets override the test defaults** and break auth-sensitive tests (e.g. `test_admin_dashboard`). Run the Python suite with the injected vars unset:
+  ```bash
+  env -u SCRAPE_API_KEY -u GOOGLE_API_KEY -u DB_USER -u DB_PASSWORD -u DB_NAME poetry run pytest
+  ```
+  The API contract tests mock the DB, so unsetting these is safe. Frontend checks (`cd app && npx tsc --noEmit`, `npx next lint`, `npx jest`) need no special handling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,90 @@
 # AGENTS.md
 
-For a full architecture, command, and deployment reference see `CLAUDE.md`. This file only adds notes specific to running the project inside a Cursor Cloud agent VM.
+For full architecture, commands, and deployment details see `CLAUDE.md`. This file covers what cloud agents need to know beyond that.
 
-## Cursor Cloud specific instructions
+## Connecting to the production database
 
-### Services & how to run them
-This is a monorepo with three services (details and commands in `CLAUDE.md`):
-- **MySQL 8** — local server (installed via apt, not Docker here). Data persists in the VM snapshot.
-- **Backend API (FastAPI/uvicorn)** — local dev runs on **:8001** (`make dev`), not :8000.
-- **Frontend (Next.js)** — runs on **:3000** (`make dev`), proxies `/api/*` to `API_INTERNAL_URL`.
+Production runs on Hetzner (MySQL inside Docker). Cloud agents connect via SSH tunnel:
 
-Standard commands live in the `Makefile` (`make dev`, `make seed`, `make check`, etc.) and `app/package.json`. Don't duplicate them; use them.
+```bash
+mkdir -p ~/.ssh
+echo "$HETZNER_SSH_KEY" > ~/.ssh/hetzner && chmod 600 ~/.ssh/hetzner
+ssh -i ~/.ssh/hetzner -o StrictHostKeyChecking=no -L 3306:localhost:3306 root@167.233.132.217 -fN
+export DB_HOST=127.0.0.1
+```
 
-### Startup caveats (non-obvious)
-- **MySQL is not auto-started on boot.** Run `sudo service mysql start` at the beginning of a session before seeding or starting the API (Docker is not used in this environment).
-- **Injected secrets override `.env`.** The VM injects `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `GOOGLE_API_KEY`, and `SCRAPE_API_KEY` as environment variables. `backend/config.py` calls `load_dotenv()` which does **not** override existing env vars, so the injected values win over anything in `.env`. The local MySQL has been provisioned with a user/database matching the injected `DB_USER`/`DB_PASSWORD`/`DB_NAME` so the app connects locally. `DB_HOST` is read from `.env` (`127.0.0.1`). If injected DB credentials ever change and auth fails, re-provision the local user:
+Verify:
+```bash
+poetry run python -c "from backend.database.connection import get_connection; c = get_connection(); c.close(); print('OK')"
+```
+
+Required secrets (injected as env vars via Cursor secrets vault): `HETZNER_SSH_KEY`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `SCRAPE_API_KEY`, `GOOGLE_API_KEY`.
+
+## Querying the database
+
+No ORM — use the connection module directly:
+
+```python
+from backend.database.connection import fetch_all, fetch_one
+
+rows = fetch_all("SELECT id, title, venue, status FROM papers WHERE status = %s LIMIT 10", ("working_paper",))
+row = fetch_one("SELECT COUNT(*) AS n FROM feed_events")
+```
+
+Key tables: `papers`, `feed_events`, `authorship`, `researchers`, `researcher_urls`, `html_content`, `paper_snapshots`, `scrape_log`, `llm_usage`. See `backend/database/schema.py` for full DDL.
+
+## Running data quality checks
+
+The deterministic test suite checks invariants against whichever database is configured:
+
+```bash
+poetry run pytest tests_data_quality/ -v --tb=short
+```
+
+Each failure identifies bad rows (not code bugs). The tests cover: feed event integrity, paper field quality, enrichment hygiene, researcher duplicates, and pipeline liveness (when `DATA_QUALITY_LIVE=1`).
+
+## Hitting the production API
+
+The backend API is at `https://econ-newsfeed.duckdns.org`. Admin endpoints require the API key:
+
+```bash
+curl -H "X-API-Key: $SCRAPE_API_KEY" https://econ-newsfeed.duckdns.org/api/admin/dashboard
+```
+
+The feed is at `/api/publications` (public, no auth needed).
+
+## Domain knowledge for auditing
+
+This project tracks economics researchers' publications. Key concepts:
+
+- **Status progression**: working_paper → revise_and_resubmit → accepted → published. Status only moves forward.
+- **Venues** are either journals (peer-reviewed, where R&R/acceptance happens) or working paper series (NBER, CEPR, IZA, RIETI, SSRN, CESifo, IMF, ECB, World Bank — these distribute papers but don't peer-review).
+- A status of R&R or accepted **at a working paper series** is an extraction error — you can't R&R at a discussion paper series.
+- A status of "working_paper" **at a known journal** is suspicious — the paper is likely published or accepted there.
+- `feed_events` drive the newsfeed UI. Bogus events (wrong status, hallucinated papers, junk titles) are user-visible.
+
+## Local development (Cursor Cloud VM)
+
+For agents doing dev work (not prod auditing), a local MySQL is available:
+
+- **Start MySQL**: `sudo service mysql start` (not auto-started on boot; not Docker)
+- **Seed schema**: `poetry run python -c "from backend.database import create_database, create_tables; create_database(); create_tables()"`
+- **Start dev servers**: Backend on :8001, frontend on :3000
+  ```bash
+  poetry run uvicorn backend.api:app --reload --port 8001 &
+  cd app && API_INTERNAL_URL=http://localhost:8001 npm run dev &
+  ```
+- **Run tests**:
+  ```bash
+  # Python (unset injected secrets so test defaults apply)
+  env -u SCRAPE_API_KEY -u GOOGLE_API_KEY -u DB_USER -u DB_PASSWORD -u DB_NAME poetry run pytest
+  # Frontend
+  cd app && npx tsc --noEmit && npx jest
+  ```
+
+### Non-obvious caveats
+
+- **Injected secrets override `.env`**: `load_dotenv()` does not override existing env vars. The local MySQL user/database must match the injected `DB_USER`/`DB_PASSWORD`/`DB_NAME`. If auth fails after credential changes, re-provision:
   ```bash
   sudo mysql -e "CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
     CREATE USER IF NOT EXISTS '${DB_USER}'@'127.0.0.1' IDENTIFIED BY '${DB_PASSWORD}';
@@ -25,13 +95,5 @@ Standard commands live in the `Makefile` (`make dev`, `make seed`, `make check`,
     GRANT ALL PRIVILEGES ON *.* TO '${DB_USER}'@'localhost' WITH GRANT OPTION;
     FLUSH PRIVILEGES;"
   ```
-  Then `make seed` (idempotent) to create tables.
-- **tmux sessions must inherit the injected secrets.** A pre-existing tmux server may have been started before secrets were injected; new sessions then inherit that stale env and the API fails with `Access denied for user ...`. If that happens, run `tmux kill-server` and recreate the session from a fresh shell (which has the injected secrets).
-- **`GOOGLE_API_KEY` powers the live LLM pipeline.** A valid Google AI Studio key has been provided as a secret and the live extraction pipeline (`make fetch` → `make extract` / `make scrape`) works end-to-end against `gemini-2.5-flash`. The API/frontend serve existing DB data even without a valid key; only the LLM extraction step needs it. If `make extract` ever fails with `400 ... Please pass a valid API key`, the `GOOGLE_API_KEY` secret needs refreshing.
-
-### Testing caveat (non-obvious)
-- `tests/conftest.py` sets its own test env via `os.environ.setdefault(...)`, so the **injected secrets override the test defaults** and break auth-sensitive tests (e.g. `test_admin_dashboard`). Run the Python suite with the injected vars unset:
-  ```bash
-  env -u SCRAPE_API_KEY -u GOOGLE_API_KEY -u DB_USER -u DB_PASSWORD -u DB_NAME poetry run pytest
-  ```
-  The API contract tests mock the DB, so unsetting these is safe. Frontend checks (`cd app && npx tsc --noEmit`, `npx next lint`, `npx jest`) need no special handling.
+- **tmux stale env**: If a tmux server predates secret injection, sessions have stale env. Fix: `tmux kill-server` and recreate from a fresh shell.
+- **`GOOGLE_API_KEY`** powers LLM extraction (Gemini). The API/frontend work without it; only extraction needs it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Standard commands live in the `Makefile` (`make dev`, `make seed`, `make check`,
   ```
   Then `make seed` (idempotent) to create tables.
 - **tmux sessions must inherit the injected secrets.** A pre-existing tmux server may have been started before secrets were injected; new sessions then inherit that stale env and the API fails with `Access denied for user ...`. If that happens, run `tmux kill-server` and recreate the session from a fresh shell (which has the injected secrets).
-- **The injected `GOOGLE_API_KEY` is not guaranteed to be a valid Google AI Studio key.** The API/frontend serve existing DB data without the LLM, but the live extraction pipeline (`make extract` / `make scrape`) needs a valid key. Without one, `make fetch` still works (downloads HTML); only LLM extraction fails.
+- **`GOOGLE_API_KEY` powers the live LLM pipeline.** A valid Google AI Studio key has been provided as a secret and the live extraction pipeline (`make fetch` → `make extract` / `make scrape`) works end-to-end against `gemini-2.5-flash`. The API/frontend serve existing DB data even without a valid key; only the LLM extraction step needs it. If `make extract` ever fails with `400 ... Please pass a valid API key`, the `GOOGLE_API_KEY` secret needs refreshing.
 
 ### Testing caveat (non-obvious)
 - `tests/conftest.py` sets its own test env via `os.environ.setdefault(...)`, so the **injected secrets override the test defaults** and break auth-sensitive tests (e.g. `test_admin_dashboard`). Run the Python suite with the injected vars unset:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,22 +6,15 @@ For full architecture, commands, and deployment details see `CLAUDE.md`. This fi
 
 Production runs on Hetzner (MySQL inside Docker). Cloud agents connect via SSH tunnel.
 
-The `HETZNER_SSH_KEY` secret is stored as the **base64 of the OpenSSH private-key body** (single line, no PEM armor), so it must be wrapped back into a PEM file before use — a plain `echo "$HETZNER_SSH_KEY" > ~/.ssh/hetzner` produces a malformed key and `ssh` then fails with `error in libcrypto`:
+The `HETZNER_SSH_KEY` secret is stored as the **base64 of the OpenSSH private-key body** (single line, no PEM armor). Do **not** use `echo "$HETZNER_SSH_KEY" > ~/.ssh/hetzner` — that produces a malformed key and `ssh` fails with `Load key ... error in libcrypto` (the tunnel never opens, so DB checks then fail with `Can't connect to MySQL server on 127.0.0.1:3306 (111)`). Instead run the helper, which reconstructs a valid `~/.ssh/hetzner` (handling PEM, literal-`\n` PEM, or base64-body forms) and validates it:
 
 ```bash
-mkdir -p ~/.ssh && chmod 700 ~/.ssh
-python3 - <<'PY'
-import os, textwrap
-k = os.environ["HETZNER_SSH_KEY"].strip()
-pem = "-----BEGIN OPENSSH PRIVATE KEY-----\n" + "\n".join(textwrap.wrap(k, 70)) + "\n-----END OPENSSH PRIVATE KEY-----\n"
-p = os.path.expanduser("~/.ssh/hetzner"); open(p, "w").write(pem); os.chmod(p, 0o600)
-PY
-ssh-keygen -y -f ~/.ssh/hetzner   # validate it parses (prints the public key)
+bash scripts/install_hetzner_key.sh
 ssh -i ~/.ssh/hetzner -o StrictHostKeyChecking=no -L 3306:localhost:3306 root@167.233.132.217 -fN
 export DB_HOST=127.0.0.1
 ```
 
-If `ssh` still reports `error in libcrypto`, the secret is truncated/malformed (a single-line paste of a multi-line key captures only the header) — re-enter the full key, base64-encoded.
+If the helper errors that the secret is truncated/malformed, re-enter the full key as base64 (`base64 -w0 ~/.ssh/hetzner`).
 
 Verify:
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,24 @@ For full architecture, commands, and deployment details see `CLAUDE.md`. This fi
 
 ## Connecting to the production database
 
-Production runs on Hetzner (MySQL inside Docker). Cloud agents connect via SSH tunnel:
+Production runs on Hetzner (MySQL inside Docker). Cloud agents connect via SSH tunnel.
+
+The `HETZNER_SSH_KEY` secret is stored as the **base64 of the OpenSSH private-key body** (single line, no PEM armor), so it must be wrapped back into a PEM file before use — a plain `echo "$HETZNER_SSH_KEY" > ~/.ssh/hetzner` produces a malformed key and `ssh` then fails with `error in libcrypto`:
 
 ```bash
-mkdir -p ~/.ssh
-echo "$HETZNER_SSH_KEY" > ~/.ssh/hetzner && chmod 600 ~/.ssh/hetzner
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+python3 - <<'PY'
+import os, textwrap
+k = os.environ["HETZNER_SSH_KEY"].strip()
+pem = "-----BEGIN OPENSSH PRIVATE KEY-----\n" + "\n".join(textwrap.wrap(k, 70)) + "\n-----END OPENSSH PRIVATE KEY-----\n"
+p = os.path.expanduser("~/.ssh/hetzner"); open(p, "w").write(pem); os.chmod(p, 0o600)
+PY
+ssh-keygen -y -f ~/.ssh/hetzner   # validate it parses (prints the public key)
 ssh -i ~/.ssh/hetzner -o StrictHostKeyChecking=no -L 3306:localhost:3306 root@167.233.132.217 -fN
 export DB_HOST=127.0.0.1
 ```
+
+If `ssh` still reports `error in libcrypto`, the secret is truncated/malformed (a single-line paste of a multi-line key captures only the header) — re-enter the full key, base64-encoded.
 
 Verify:
 ```bash
@@ -65,11 +75,11 @@ This project tracks economics researchers' publications. Key concepts:
 
 ## Local development (Cursor Cloud VM)
 
-For agents doing dev work (not prod auditing), a local MySQL is available:
+For agents doing dev work (not prod auditing), a local MySQL is available (the dev API on :8001 + frontend on :3000 use it, not the prod tunnel):
 
 - **Start MySQL**: `sudo service mysql start` (not auto-started on boot; not Docker)
-- **Seed schema**: `poetry run python -c "from backend.database import create_database, create_tables; create_database(); create_tables()"`
-- **Start dev servers**: Backend on :8001, frontend on :3000
+- **Seed schema**: `make seed` (idempotent), or `poetry run python -c "from backend.database import create_database, create_tables; create_database(); create_tables()"`
+- **Start dev servers** (`make dev` runs both):
   ```bash
   poetry run uvicorn backend.api:app --reload --port 8001 &
   cd app && API_INTERNAL_URL=http://localhost:8001 npm run dev &
@@ -84,7 +94,7 @@ For agents doing dev work (not prod auditing), a local MySQL is available:
 
 ### Non-obvious caveats
 
-- **Injected secrets override `.env`**: `load_dotenv()` does not override existing env vars. The local MySQL user/database must match the injected `DB_USER`/`DB_PASSWORD`/`DB_NAME`. If auth fails after credential changes, re-provision:
+- **Injected secrets override `.env`**: `load_dotenv()` does not override existing env vars. The local MySQL user/database must match the injected `DB_USER`/`DB_PASSWORD`/`DB_NAME` (`DB_HOST` is read from `.env` as `127.0.0.1`). If auth fails after credential changes, re-provision, then `make seed`:
   ```bash
   sudo mysql -e "CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
     CREATE USER IF NOT EXISTS '${DB_USER}'@'127.0.0.1' IDENTIFIED BY '${DB_PASSWORD}';
@@ -95,5 +105,5 @@ For agents doing dev work (not prod auditing), a local MySQL is available:
     GRANT ALL PRIVILEGES ON *.* TO '${DB_USER}'@'localhost' WITH GRANT OPTION;
     FLUSH PRIVILEGES;"
   ```
-- **tmux stale env**: If a tmux server predates secret injection, sessions have stale env. Fix: `tmux kill-server` and recreate from a fresh shell.
-- **`GOOGLE_API_KEY`** powers LLM extraction (Gemini). The API/frontend work without it; only extraction needs it.
+- **tmux stale env**: If a tmux server predates secret injection, its sessions have stale env and the API fails with `Access denied for user ...`. Fix: `tmux kill-server` and recreate the session from a fresh shell (which has the injected secrets).
+- **`GOOGLE_API_KEY`** powers the live LLM extraction pipeline (`make fetch` → `make extract`/`make scrape`, Gemini). The API/frontend serve existing DB data without it; only extraction needs a valid key. If `make extract` fails with `400 ... Please pass a valid API key`, the secret needs refreshing.

--- a/backend/database/schema.py
+++ b/backend/database/schema.py
@@ -855,39 +855,6 @@ def create_tables() -> None:
                     except Exception as e:
                         logging.warning("Migration: feed_events status ENUMs: %s", e)
 
-                    # Backfill: flip working_paper → work_in_progress for papers with no links
-                    try:
-                        cursor.execute("""
-                            UPDATE papers p
-                            SET p.status = 'work_in_progress'
-                            WHERE p.status = 'working_paper'
-                              AND NOT EXISTS (
-                                  SELECT 1 FROM paper_links pl WHERE pl.paper_id = p.id
-                              )
-                              AND (p.draft_url IS NULL OR p.draft_url_status != 'valid')
-                        """)
-                        backfilled = cursor.rowcount
-                        conn.commit()
-                        logging.info("Migration: backfilled %d papers to work_in_progress", backfilled)
-                    except Exception as e:
-                        logging.warning("Migration: work_in_progress backfill: %s", e)
-
-                    # Update feed_events to reflect backfilled statuses
-                    try:
-                        cursor.execute("""
-                            UPDATE feed_events fe
-                            JOIN papers p ON p.id = fe.paper_id
-                            SET fe.new_status = 'work_in_progress'
-                            WHERE fe.event_type = 'new_paper'
-                              AND fe.new_status = 'working_paper'
-                              AND p.status = 'work_in_progress'
-                        """)
-                        events_updated = cursor.rowcount
-                        conn.commit()
-                        logging.info("Migration: updated %d feed_events to work_in_progress", events_updated)
-                    except Exception as e:
-                        logging.warning("Migration: feed_events backfill: %s", e)
-
                     # Add has_top5_pub denormalized flag to researchers
                     try:
                         cursor.execute("""
@@ -929,42 +896,6 @@ def create_tables() -> None:
                             logging.info("Migration: backfilled has_top5_pub for %d researchers", backfilled)
                     except Exception as e:
                         logging.warning("Migration: has_top5_pub backfill: %s", e)
-
-                    # Revert all work_in_progress → working_paper.
-                    # WIP/WP distinction is now LLM-determined at extraction time;
-                    # existing WIP data was set by a draft_url heuristic that is removed.
-                    try:
-                        cursor.execute(
-                            "SELECT EXISTS(SELECT 1 FROM papers WHERE status = 'work_in_progress' LIMIT 1)"
-                        )
-                        if cursor.fetchone()[0]:
-                            cursor.execute("""
-                                UPDATE papers SET status = 'working_paper'
-                                WHERE status = 'work_in_progress'
-                            """)
-                            papers_reverted = cursor.rowcount
-
-                            cursor.execute("""
-                                UPDATE paper_snapshots SET status = 'working_paper'
-                                WHERE status = 'work_in_progress'
-                            """)
-                            snapshots_reverted = cursor.rowcount
-
-                            cursor.execute("""
-                                DELETE FROM feed_events
-                                WHERE new_status = 'work_in_progress'
-                                   OR old_status = 'work_in_progress'
-                            """)
-                            events_deleted = cursor.rowcount
-                            conn.commit()
-
-                            logging.info(
-                                "Migration: reverted %d papers and %d snapshots from "
-                                "work_in_progress to working_paper, deleted %d WIP feed events",
-                                papers_reverted, snapshots_reverted, events_deleted,
-                            )
-                    except Exception as e:
-                        logging.warning("Migration: WIP revert: %s", e)
 
                     # Create url_discoveries table for URL discovery pipeline
                     try:

--- a/backend/database/schema.py
+++ b/backend/database/schema.py
@@ -855,6 +855,39 @@ def create_tables() -> None:
                     except Exception as e:
                         logging.warning("Migration: feed_events status ENUMs: %s", e)
 
+                    # Backfill: flip working_paper → work_in_progress for papers with no links
+                    try:
+                        cursor.execute("""
+                            UPDATE papers p
+                            SET p.status = 'work_in_progress'
+                            WHERE p.status = 'working_paper'
+                              AND NOT EXISTS (
+                                  SELECT 1 FROM paper_links pl WHERE pl.paper_id = p.id
+                              )
+                              AND (p.draft_url IS NULL OR p.draft_url_status != 'valid')
+                        """)
+                        backfilled = cursor.rowcount
+                        conn.commit()
+                        logging.info("Migration: backfilled %d papers to work_in_progress", backfilled)
+                    except Exception as e:
+                        logging.warning("Migration: work_in_progress backfill: %s", e)
+
+                    # Update feed_events to reflect backfilled statuses
+                    try:
+                        cursor.execute("""
+                            UPDATE feed_events fe
+                            JOIN papers p ON p.id = fe.paper_id
+                            SET fe.new_status = 'work_in_progress'
+                            WHERE fe.event_type = 'new_paper'
+                              AND fe.new_status = 'working_paper'
+                              AND p.status = 'work_in_progress'
+                        """)
+                        events_updated = cursor.rowcount
+                        conn.commit()
+                        logging.info("Migration: updated %d feed_events to work_in_progress", events_updated)
+                    except Exception as e:
+                        logging.warning("Migration: feed_events backfill: %s", e)
+
                     # Add has_top5_pub denormalized flag to researchers
                     try:
                         cursor.execute("""
@@ -896,6 +929,42 @@ def create_tables() -> None:
                             logging.info("Migration: backfilled has_top5_pub for %d researchers", backfilled)
                     except Exception as e:
                         logging.warning("Migration: has_top5_pub backfill: %s", e)
+
+                    # Revert all work_in_progress → working_paper.
+                    # WIP/WP distinction is now LLM-determined at extraction time;
+                    # existing WIP data was set by a draft_url heuristic that is removed.
+                    try:
+                        cursor.execute(
+                            "SELECT EXISTS(SELECT 1 FROM papers WHERE status = 'work_in_progress' LIMIT 1)"
+                        )
+                        if cursor.fetchone()[0]:
+                            cursor.execute("""
+                                UPDATE papers SET status = 'working_paper'
+                                WHERE status = 'work_in_progress'
+                            """)
+                            papers_reverted = cursor.rowcount
+
+                            cursor.execute("""
+                                UPDATE paper_snapshots SET status = 'working_paper'
+                                WHERE status = 'work_in_progress'
+                            """)
+                            snapshots_reverted = cursor.rowcount
+
+                            cursor.execute("""
+                                DELETE FROM feed_events
+                                WHERE new_status = 'work_in_progress'
+                                   OR old_status = 'work_in_progress'
+                            """)
+                            events_deleted = cursor.rowcount
+                            conn.commit()
+
+                            logging.info(
+                                "Migration: reverted %d papers and %d snapshots from "
+                                "work_in_progress to working_paper, deleted %d WIP feed events",
+                                papers_reverted, snapshots_reverted, events_deleted,
+                            )
+                    except Exception as e:
+                        logging.warning("Migration: WIP revert: %s", e)
 
                     # Create url_discoveries table for URL discovery pipeline
                     try:

--- a/scripts/install_hetzner_key.sh
+++ b/scripts/install_hetzner_key.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Materialize the Hetzner SSH private key from the HETZNER_SSH_KEY secret into a
+# valid OpenSSH key file, robust to how the secret is stored.
+#
+# Why this exists: a naive `echo "$HETZNER_SSH_KEY" > ~/.ssh/hetzner` fails with
+# `Load key ... error in libcrypto` whenever the secret is NOT a verbatim,
+# newline-preserving PEM — which is the common case, because pasting a multi-line
+# key into a single-line secret field either truncates it or strips newlines.
+#
+# This script auto-detects and handles all three shapes:
+#   1. Proper multi-line PEM (BEGIN/END + real newlines)  -> written as-is
+#   2. PEM with literal "\n" sequences instead of newlines  -> newlines restored
+#   3. base64 of the raw OpenSSH key body (no PEM armor)     -> wrapped in armor
+#
+# Usage:
+#   bash scripts/install_hetzner_key.sh            # writes ~/.ssh/hetzner
+#   KEY_PATH=/tmp/k bash scripts/install_hetzner_key.sh
+# Then:
+#   ssh -i ~/.ssh/hetzner -o IdentitiesOnly=yes root@167.233.132.217
+set -euo pipefail
+
+KEY_PATH="${KEY_PATH:-$HOME/.ssh/hetzner}"
+
+if [ -z "${HETZNER_SSH_KEY:-}" ]; then
+    echo "ERROR: HETZNER_SSH_KEY is not set in the environment." >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$KEY_PATH")"
+chmod 700 "$(dirname "$KEY_PATH")" 2>/dev/null || true
+
+KEY_PATH="$KEY_PATH" python3 - <<'PY'
+import base64
+import os
+import sys
+import textwrap
+
+raw = os.environ["HETZNER_SSH_KEY"]
+path = os.environ["KEY_PATH"]
+
+def write(pem: str) -> None:
+    if not pem.endswith("\n"):
+        pem += "\n"
+    with open(path, "w") as f:
+        f.write(pem)
+    os.chmod(path, 0o600)
+
+if "-----BEGIN" in raw:
+    # PEM provided directly. Restore newlines if they were flattened to "\n".
+    pem = raw.replace("\\n", "\n") if "\n" not in raw and "\\n" in raw else raw
+    write(pem.strip())
+else:
+    # Assume base64 of the raw OpenSSH key body (no armor). Validate it really
+    # is an OpenSSH key before wrapping, to fail loudly on a truncated secret.
+    try:
+        decoded = base64.b64decode(raw.strip(), validate=False)
+    except Exception as e:  # noqa: BLE001
+        sys.exit(f"ERROR: HETZNER_SSH_KEY is neither PEM nor valid base64: {e}")
+    if not decoded.startswith(b"openssh-key-v1"):
+        sys.exit(
+            "ERROR: HETZNER_SSH_KEY looks truncated/malformed "
+            "(base64 body does not start with 'openssh-key-v1'). "
+            "Re-enter the FULL key, base64-encoded (`base64 -w0 ~/.ssh/hetzner`)."
+        )
+    body = "\n".join(textwrap.wrap(raw.strip(), 70))
+    write(f"-----BEGIN OPENSSH PRIVATE KEY-----\n{body}\n-----END OPENSSH PRIVATE KEY-----")
+
+print(f"Wrote {path}")
+PY
+
+# Validate the key parses (exercises libcrypto, prints the public key on success).
+if ssh-keygen -y -f "$KEY_PATH" >/dev/null 2>&1; then
+    echo "Key validated OK: $KEY_PATH"
+else
+    echo "ERROR: ssh-keygen could not parse $KEY_PATH — the secret is malformed." >&2
+    exit 1
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Econ Newsfeed dev environment (FastAPI backend + Next.js frontend + MySQL) in the Cursor Cloud VM, documents non-obvious startup/testing caveats, and adds a robust loader for the Hetzner SSH key.

- `AGENTS.md` — `## Cursor Cloud specific instructions`: local MySQL startup, injected secrets overriding `.env` (+ DB user re-provisioning), tmux stale-env gotcha, live LLM pipeline, pytest env-unset caveat, and prod DB tunnel via the new key helper.
- `scripts/install_hetzner_key.sh` — reconstructs a valid `~/.ssh/hetzner` from the `HETZNER_SSH_KEY` secret regardless of how it's stored (multi-line PEM, literal-`\n` PEM, or base64 of the key body) and validates it with `ssh-keygen`. Fixes the recurring `Load key ... error in libcrypto` → `Can't connect to MySQL ... (111)` failure caused by `echo "$HETZNER_SSH_KEY" > ~/.ssh/hetzner` on a base64-encoded secret.
- Registers a minimal update script (`poetry install` + `npm install --prefix app`).

No application code modified. `.env` / `app/.env.local` are gitignored.

## Walkthrough

End-to-end demo (newsfeed, paper detail, researchers directory, researcher profile):

[econ_newsfeed_demo.mp4](https://cursor.com/agents/bc-b7532c4d-4a8a-42aa-a835-5f0b72c18ebc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fecon_newsfeed_demo.mp4)

Live LLM pipeline — 34 real papers extracted from Benjamin Moll's site via `make fetch` + `make extract` (Gemini):

[Live-extracted publications on researcher profile](https://cursor.com/agents/bc-b7532c4d-4a8a-42aa-a835-5f0b72c18ebc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flive_extracted_papers.webp)

## Verification

- Backend `:8001` (`/api/health` → 200), frontend `:3000`.
- Python tests `1308 passed` (injected secrets unset); frontend `tsc` clean, `jest` 137 passed, `next lint` warnings only.
- `scripts/install_hetzner_key.sh` produces a valid key (`ssh-keygen -y` OK) and `ssh root@167.233.132.217` connects (`SSH_OK`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7532c4d-4a8a-42aa-a835-5f0b72c18ebc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7532c4d-4a8a-42aa-a835-5f0b72c18ebc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

