### PR TITLE
Make journal/venue more prominent in feed cards

### DIFF
--- a/app/src/components/PublicationCard.tsx
+++ b/app/src/components/PublicationCard.tsx
@@ -85,7 +85,7 @@ export default function PublicationCard({
         {!isStatusChange && venueYear && (
           <>
             <span className="text-[var(--muted)]">{"  ·  "}</span>
-            <span className="italic text-[var(--muted)]">{venueYear}</span>
+            <span className="italic text-[var(--ink2)]">{venueYear}</span>
           </>
         )}
       </p>
@@ -107,7 +107,7 @@ export default function PublicationCard({
             {newLabel}
           </span>
           <span>at</span>
-          <span className="italic">{venueYear}</span>
+          <span className="italic text-[var(--ink2)] font-medium">{venueYear}</span>
         </p>
       )}
 


### PR DESCRIPTION
## Summary
- Journal names in the feed were grey (`--muted`), making them hard to scan
- Changed venue text to `--ink2` (darker secondary color) on both card types
- Added `font-medium` to status-change cards where the journal is the key piece of information (R&R at _where_, accepted at _where_)

## Test plan
- [x] Verified visually against prod data on Publications tab
- [ ] Check feed on desktop and mobile after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)