### PR TITLE
Improve feed UX: author affiliations, clear-filters fix, dense researcher cards

### DIFF
--- a/app/src/__tests__/publication-utils.test.ts
+++ b/app/src/__tests__/publication-utils.test.ts
@@ -3,21 +3,26 @@ import { formatAuthor } from "@/lib/publication-utils";
 describe("formatAuthor", () => {
   it("formats author with first and last name", () => {
     const result = formatAuthor({ id: 1, first_name: "Jane", last_name: "Doe" });
-    expect(result).toEqual({ display: "J. Doe", id: 1 });
+    expect(result).toEqual({ display: "Jane Doe", affiliation: null, id: 1 });
+  });
+
+  it("includes affiliation when present", () => {
+    const result = formatAuthor({ id: 1, first_name: "Jane", last_name: "Doe", affiliation: "MIT" });
+    expect(result).toEqual({ display: "Jane Doe", affiliation: "MIT", id: 1 });
   });
 
   it("handles null first_name without crashing", () => {
     const result = formatAuthor({ id: 2, first_name: null as unknown as string, last_name: "Smith" });
-    expect(result).toEqual({ display: "Smith", id: 2 });
+    expect(result).toEqual({ display: "Smith", affiliation: null, id: 2 });
   });
 
   it("handles undefined first_name without crashing", () => {
     const result = formatAuthor({ id: 3, first_name: undefined as unknown as string, last_name: "Jones" });
-    expect(result).toEqual({ display: "Jones", id: 3 });
+    expect(result).toEqual({ display: "Jones", affiliation: null, id: 3 });
   });
 
   it("handles empty string first_name", () => {
     const result = formatAuthor({ id: 4, first_name: "", last_name: "Lee" });
-    expect(result).toEqual({ display: "Lee", id: 4 });
+    expect(result).toEqual({ display: "Lee", affiliation: null, id: 4 });
   });
 });

--- a/app/src/app/NewsfeedContent.tsx
+++ b/app/src/app/NewsfeedContent.tsx
@@ -460,7 +460,7 @@ export default function NewsfeedContent() {
               : `Showing ${data.items.length.toLocaleString()} of ${data.total.toLocaleString()} updates`}
           </p>
         )}
-        {chips.length === 1 && (
+        {chips.length > 0 && (
           <button
             onClick={clearAll}
             className="text-xs text-[var(--accent)] bg-transparent border-none cursor-pointer p-0"

--- a/app/src/app/__tests__/NewsfeedContent.test.tsx
+++ b/app/src/app/__tests__/NewsfeedContent.test.tsx
@@ -15,7 +15,7 @@ const page1: PaginatedResponse<Publication> = {
     {
       id: 1,
       title: "Immigration and Wages",
-      authors: [{ id: 1, first_name: "Max", last_name: "Steinhardt" }],
+      authors: [{ id: 1, first_name: "Max", last_name: "Steinhardt", affiliation: null }],
       year: "2024",
       venue: "JLE",
       source_url: null,
@@ -32,7 +32,7 @@ const page1: PaginatedResponse<Publication> = {
     {
       id: 2,
       title: "Trade Shocks",
-      authors: [{ id: 2, first_name: "Jane", last_name: "Doe" }],
+      authors: [{ id: 2, first_name: "Jane", last_name: "Doe", affiliation: null }],
       year: "2025",
       venue: "WP",
       source_url: null,
@@ -58,7 +58,7 @@ const page2: PaginatedResponse<Publication> = {
     {
       id: 3,
       title: "Fiscal Policy in Europe",
-      authors: [{ id: 1, first_name: "Max", last_name: "Steinhardt" }],
+      authors: [{ id: 1, first_name: "Max", last_name: "Steinhardt", affiliation: null }],
       year: "2023",
       venue: "QJE",
       source_url: null,

--- a/app/src/app/papers/__tests__/PaperDetailContent.test.tsx
+++ b/app/src/app/papers/__tests__/PaperDetailContent.test.tsx
@@ -13,8 +13,8 @@ const mockPublication: PublicationDetail = {
   id: 1,
   title: "Trade and Wages: Evidence from Germany",
   authors: [
-    { id: 10, first_name: "Max", last_name: "Steinhardt" },
-    { id: 11, first_name: "Jane", last_name: "Doe" },
+    { id: 10, first_name: "Max", last_name: "Steinhardt", affiliation: "FU Berlin" },
+    { id: 11, first_name: "Jane", last_name: "Doe", affiliation: null },
   ],
   year: "2024",
   venue: "Journal of Labor Economics",

--- a/app/src/app/researchers/ResearchersContent.tsx
+++ b/app/src/app/researchers/ResearchersContent.tsx
@@ -247,7 +247,7 @@ export default function ResearchersContent() {
               : `Showing ${researchers.length.toLocaleString()} researcher${researchers.length === 1 ? "" : "s"}`}
           </p>
         )}
-        {chips.length === 1 && (
+        {chips.length > 0 && (
           <button
             onClick={clearAll}
             className="text-xs text-[var(--accent)] bg-transparent border-none cursor-pointer p-0"

--- a/app/src/app/researchers/__tests__/ResearcherDetailContent.test.tsx
+++ b/app/src/app/researchers/__tests__/ResearcherDetailContent.test.tsx
@@ -23,7 +23,7 @@ const researcher: ResearcherDetail = {
     {
       id: 1,
       title: "Immigration and Wages",
-      authors: [{ id: 1, first_name: "Max Friedrich", last_name: "Steinhardt" }],
+      authors: [{ id: 1, first_name: "Max Friedrich", last_name: "Steinhardt", affiliation: "Freie Universität Berlin" }],
       year: "2024",
       venue: "JLE",
       source_url: null,
@@ -41,8 +41,8 @@ const researcher: ResearcherDetail = {
       id: 2,
       title: "Trade Shocks",
       authors: [
-        { id: 1, first_name: "Max Friedrich", last_name: "Steinhardt" },
-        { id: 2, first_name: "Jane", last_name: "Doe" },
+        { id: 1, first_name: "Max Friedrich", last_name: "Steinhardt", affiliation: "Freie Universität Berlin" },
+        { id: 2, first_name: "Jane", last_name: "Doe", affiliation: null },
       ],
       year: "2025",
       venue: "WP",
@@ -89,7 +89,7 @@ describe("ResearcherDetailContent", () => {
     });
 
     expect(screen.getByText(/Professor/)).toBeInTheDocument();
-    expect(screen.getByText(/Freie Universität Berlin/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Freie Universität Berlin/).length).toBeGreaterThan(0);
     expect(screen.getByText("Immigration and Wages")).toBeInTheDocument();
     expect(screen.getByText("Trade Shocks")).toBeInTheDocument();
   });

--- a/app/src/components/PublicationCard.tsx
+++ b/app/src/components/PublicationCard.tsx
@@ -70,7 +70,7 @@ export default function PublicationCard({
       <p className="mt-[7px] m-0 text-sm leading-normal text-[var(--ink2)]">
         {authors.map((a, i) => (
           <span key={a.id}>
-            {i > 0 && ", "}
+            {i > 0 && <span className="text-[var(--muted)]">{" · "}</span>}
             <Link
               href={`/researchers/${a.id}`}
               className={primaryAuthorId != null && a.id === primaryAuthorId
@@ -80,12 +80,15 @@ export default function PublicationCard({
             >
               {a.display}
             </Link>
+            {a.affiliation && (
+              <span className="text-[var(--muted)]">{` (${a.affiliation})`}</span>
+            )}
           </span>
         ))}
         {!isStatusChange && venueYear && (
           <>
             <span className="text-[var(--muted)]">{"  ·  "}</span>
-            <span className="italic text-[var(--muted)]">{venueYear}</span>
+            <span className="italic text-[var(--ink2)]">{venueYear}</span>
           </>
         )}
       </p>
@@ -107,7 +110,7 @@ export default function PublicationCard({
             {newLabel}
           </span>
           <span>at</span>
-          <span className="italic">{venueYear}</span>
+          <span className="italic text-[var(--ink2)] font-medium">{venueYear}</span>
         </p>
       )}
 

--- a/app/src/components/ResearcherCard.tsx
+++ b/app/src/components/ResearcherCard.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import AffiliationLine from "@/components/AffiliationLine";
 import type { Researcher } from "@/lib/types";
 import FollowButton from "@/components/FollowButton";
 
@@ -8,55 +7,56 @@ export default function ResearcherCard({
 }: {
   researcher: Researcher;
 }) {
+  const affParts = [researcher.position, researcher.affiliation].filter(Boolean);
+
   return (
-    <article className="border-b border-[var(--line)] py-[var(--rowpad)]">
-      <div className="flex items-start justify-between gap-3">
-        <h3 className="font-serif font-semibold text-[var(--ink)] text-lg leading-snug">
-          <Link
-            href={`/researchers/${researcher.id}`}
-            className="hover:text-[var(--accent)] transition-colors"
-          >
-            {researcher.first_name} {researcher.last_name}
-          </Link>
-        </h3>
-        <FollowButton researcherId={researcher.id} size="sm" />
-      </div>
+    <article className="border-b border-[var(--line)] py-[18px]">
+      <div className="flex items-baseline justify-between gap-4 flex-wrap">
+        {/* Left: name + affiliation + fields */}
+        <div className="min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <h3 className="font-serif font-semibold text-[var(--ink)] text-[17px] leading-snug">
+              <Link
+                href={`/researchers/${researcher.id}`}
+                className="hover:text-[var(--accent)] transition-colors"
+              >
+                {researcher.first_name} {researcher.last_name}
+              </Link>
+            </h3>
+            {affParts.length > 0 && (
+              <span className="text-sm text-[var(--ink2)]">
+                {affParts.join(" · ")}
+              </span>
+            )}
+          </div>
+          {researcher.fields?.length > 0 && (
+            <p className="mt-0.5 text-xs text-[var(--muted)]">
+              {researcher.fields.map((f) => f.name).join(" · ")}
+            </p>
+          )}
+        </div>
 
-      <AffiliationLine
-        position={researcher.position}
-        affiliation={researcher.affiliation}
-        className="mt-1 text-sm text-[var(--ink2)]"
-      />
-
-      <p className="mt-1 text-sm text-[var(--muted)]">
-        {researcher.publication_count} publications tracked
-        {researcher.website_url && (
-          <>
-            {" · "}
+        {/* Right: paper count + site link + follow */}
+        <div className="flex items-center gap-4 shrink-0 text-sm">
+          <span className="text-[var(--muted)] whitespace-nowrap">
+            {researcher.publication_count} {researcher.publication_count === 1 ? "paper" : "papers"}
+          </span>
+          {researcher.website_url && (
             <a
               href={researcher.website_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-[var(--accent)] hover:underline"
+              className="text-[11px] font-semibold tracking-[0.08em] uppercase text-[var(--ink2)] hover:text-[var(--accent)] transition-colors inline-flex items-center gap-1"
             >
-              Website &rarr;
+              Site
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
+              </svg>
             </a>
-          </>
-        )}
-      </p>
-
-      {researcher.fields?.length > 0 && (
-        <div className="mt-2.5 flex flex-wrap gap-1.5">
-          {researcher.fields.map((field) => (
-            <span
-              key={field.id}
-              className="text-[10px] font-semibold uppercase tracking-wider text-[var(--muted)] bg-[var(--line)] px-2 py-0.5 rounded-sm"
-            >
-              {field.name}
-            </span>
-          ))}
+          )}
+          <FollowButton researcherId={researcher.id} size="sm" />
         </div>
-      )}
+      </div>
     </article>
   );
 }

--- a/app/src/components/ResearcherCardSkeleton.tsx
+++ b/app/src/components/ResearcherCardSkeleton.tsx
@@ -1,9 +1,16 @@
 export default function ResearcherCardSkeleton() {
   return (
-    <div className="border-b border-[var(--line)] py-[var(--rowpad)] animate-pulse">
-      <div className="h-5 bg-[var(--line)] rounded-sm w-1/3" />
-      <div className="mt-2.5 h-4 bg-[var(--line)] rounded-sm w-2/3 opacity-60" />
-      <div className="mt-2 h-4 bg-[var(--line)] rounded-sm w-1/4 opacity-40" />
+    <div className="border-b border-[var(--line)] py-[18px] animate-pulse">
+      <div className="flex items-baseline justify-between gap-4">
+        <div className="flex items-baseline gap-2 flex-1">
+          <div className="h-5 bg-[var(--line)] rounded-sm w-36" />
+          <div className="h-4 bg-[var(--line)] rounded-sm w-48 opacity-60" />
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="h-4 bg-[var(--line)] rounded-sm w-16 opacity-40" />
+          <div className="h-7 bg-[var(--line)] rounded-sm w-16 opacity-40" />
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/src/components/__tests__/PublicationCard.edge-cases.test.tsx
+++ b/app/src/components/__tests__/PublicationCard.edge-cases.test.tsx
@@ -15,7 +15,7 @@ jest.mock("next/navigation", () => ({
 const basePublication: Publication = {
   id: 1,
   title: "Test Paper Title",
-  authors: [{ id: 1, first_name: "Jane", last_name: "Doe" }],
+  authors: [{ id: 1, first_name: "Jane", last_name: "Doe", affiliation: null }],
   year: null,
   venue: null,
   source_url: null,

--- a/app/src/components/__tests__/PublicationCard.test.tsx
+++ b/app/src/components/__tests__/PublicationCard.test.tsx
@@ -10,8 +10,8 @@ const publication: Publication = {
   id: 1,
   title: "Immigration and Wages: Evidence from Germany",
   authors: [
-    { id: 1, first_name: "Max", last_name: "Steinhardt" },
-    { id: 2, first_name: "Jane", last_name: "Doe" },
+    { id: 1, first_name: "Max", last_name: "Steinhardt", affiliation: null },
+    { id: 2, first_name: "Jane", last_name: "Doe", affiliation: null },
   ],
   year: "2024",
   venue: "Journal of Labor Economics",
@@ -37,8 +37,8 @@ describe("PublicationCard", () => {
 
   it("renders author names", () => {
     render(<PublicationCard publication={publication} />);
-    expect(screen.getByText(/M\. Steinhardt/)).toBeInTheDocument();
-    expect(screen.getByText(/J\. Doe/)).toBeInTheDocument();
+    expect(screen.getByText(/Max Steinhardt/)).toBeInTheDocument();
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
   });
 
   it("renders venue and year", () => {
@@ -71,7 +71,7 @@ describe("PublicationCard navigation", () => {
 
   it("has separate author links that don't point to the paper", () => {
     render(<PublicationCard publication={publication} />);
-    const authorLink = screen.getByText(/M\. Steinhardt/).closest("a");
+    const authorLink = screen.getByText(/Max Steinhardt/).closest("a");
     expect(authorLink).toHaveAttribute("href", "/researchers/1");
   });
 });

--- a/app/src/components/__tests__/ResearcherCard.test.tsx
+++ b/app/src/components/__tests__/ResearcherCard.test.tsx
@@ -34,13 +34,13 @@ describe("ResearcherCard", () => {
 
   it("renders publication count", () => {
     render(<ResearcherCard researcher={researcher} />);
-    expect(screen.getByText(/23 publications/)).toBeInTheDocument();
+    expect(screen.getByText(/23 papers/)).toBeInTheDocument();
   });
 
-  it("shows placeholder when affiliation and position are null", () => {
+  it("renders without affiliation when position and affiliation are null", () => {
     const noAffiliation = { ...researcher, position: null, affiliation: null };
     render(<ResearcherCard researcher={noAffiliation} />);
-    expect(screen.getByText("Affiliation unknown")).toBeInTheDocument();
+    expect(screen.getByText("Max Friedrich Steinhardt")).toBeInTheDocument();
   });
 
   it("links to the researcher detail page", () => {

--- a/app/src/lib/__tests__/api.test.ts
+++ b/app/src/lib/__tests__/api.test.ts
@@ -6,7 +6,7 @@ const mockPublicationsResponse: PaginatedResponse<Publication> = {
     {
       id: 1,
       title: "Immigration and Wages",
-      authors: [{ id: 1, first_name: "Max", last_name: "Steinhardt" }],
+      authors: [{ id: 1, first_name: "Max", last_name: "Steinhardt", affiliation: null }],
       year: "2024",
       venue: "Journal of Labor Economics",
       source_url: "https://example.com/paper",
@@ -61,7 +61,7 @@ const mockResearcherDetail: ResearcherDetail = {
     {
       id: 1,
       title: "Immigration and Wages",
-      authors: [{ id: 1, first_name: "Max", last_name: "Steinhardt" }],
+      authors: [{ id: 1, first_name: "Max", last_name: "Steinhardt", affiliation: null }],
       year: "2024",
       venue: "Journal of Labor Economics",
       source_url: null,

--- a/app/src/lib/publication-utils.ts
+++ b/app/src/lib/publication-utils.ts
@@ -53,9 +53,11 @@ export function chipForStatus(label: string): { text: string; bg: string; border
   return map[label] || { text: "var(--ink2)", bg: "transparent", border: "var(--line2)" };
 }
 
-export function formatAuthor(author: { id: number; first_name: string; last_name: string }) {
-  const initial = author.first_name?.charAt(0);
-  return { display: initial ? `${initial}. ${author.last_name}` : author.last_name, id: author.id };
+export function formatAuthor(author: { id: number; first_name: string; last_name: string; affiliation?: string | null }) {
+  const name = author.first_name
+    ? `${author.first_name} ${author.last_name}`
+    : author.last_name;
+  return { display: name, affiliation: author.affiliation ?? null, id: author.id };
 }
 
 export function formatDate(iso: string): string {

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -2,6 +2,7 @@ export interface Author {
   id: number;
   first_name: string;
   last_name: string;
+  affiliation: string | null;
 }
 
 export type PublicationStatus =

--- a/backend/api.py
+++ b/backend/api.py
@@ -166,6 +166,7 @@ class AuthorResponse(BaseModel):
     id: int
     first_name: str
     last_name: str
+    affiliation: str | None = None
 
 class CoAuthorResponse(BaseModel):
     display_name: str

--- a/backend/database/papers.py
+++ b/backend/database/papers.py
@@ -127,7 +127,7 @@ def get_authors_for_papers(paper_ids: list[int]) -> dict[int, list[dict]]:
     placeholders = ",".join(["%s"] * len(paper_ids))
     rows = fetch_all(
         f"""
-        SELECT a.publication_id, r.id AS researcher_id, r.first_name, r.last_name
+        SELECT a.publication_id, r.id AS researcher_id, r.first_name, r.last_name, r.affiliation
         FROM authorship a
         JOIN researchers r ON r.id = a.researcher_id
         WHERE a.publication_id IN ({placeholders})
@@ -141,6 +141,7 @@ def get_authors_for_papers(paper_ids: list[int]) -> dict[int, list[dict]]:
             "id": row['researcher_id'],
             "first_name": row['first_name'],
             "last_name": row['last_name'],
+            "affiliation": row['affiliation'],
         })
     return result
 

--- a/tests/test_db_papers.py
+++ b/tests/test_db_papers.py
@@ -28,19 +28,19 @@ class TestGetAuthorsForPapers:
 
     def test_groups_by_paper_id(self):
         rows = [
-            {"publication_id": 1, "researcher_id": 10, "first_name": "Alice", "last_name": "Smith"},
-            {"publication_id": 1, "researcher_id": 11, "first_name": "Bob", "last_name": "Jones"},
-            {"publication_id": 2, "researcher_id": 12, "first_name": "Carol", "last_name": "Lee"},
+            {"publication_id": 1, "researcher_id": 10, "first_name": "Alice", "last_name": "Smith", "affiliation": "MIT"},
+            {"publication_id": 1, "researcher_id": 11, "first_name": "Bob", "last_name": "Jones", "affiliation": None},
+            {"publication_id": 2, "researcher_id": 12, "first_name": "Carol", "last_name": "Lee", "affiliation": "Harvard"},
         ]
         with patch("backend.database.papers.fetch_all", return_value=rows) as mock_fetch:
             from backend.database.papers import get_authors_for_papers
             result = get_authors_for_papers([1, 2])
 
         assert len(result[1]) == 2
-        assert result[1][0] == {"id": 10, "first_name": "Alice", "last_name": "Smith"}
-        assert result[1][1] == {"id": 11, "first_name": "Bob", "last_name": "Jones"}
+        assert result[1][0] == {"id": 10, "first_name": "Alice", "last_name": "Smith", "affiliation": "MIT"}
+        assert result[1][1] == {"id": 11, "first_name": "Bob", "last_name": "Jones", "affiliation": None}
         assert len(result[2]) == 1
-        assert result[2][0] == {"id": 12, "first_name": "Carol", "last_name": "Lee"}
+        assert result[2][0] == {"id": 12, "first_name": "Carol", "last_name": "Lee", "affiliation": "Harvard"}
 
     def test_sql_uses_parameterized_in_clause(self):
         with patch("backend.database.papers.fetch_all", return_value=[]) as mock_fetch:
@@ -59,7 +59,7 @@ class TestGetAuthorsForPapers:
 
     def test_returns_id_field_from_researcher_id(self):
         rows = [
-            {"publication_id": 5, "researcher_id": 99, "first_name": "Dan", "last_name": "Brown"},
+            {"publication_id": 5, "researcher_id": 99, "first_name": "Dan", "last_name": "Brown", "affiliation": None},
         ]
         with patch("backend.database.papers.fetch_all", return_value=rows):
             from backend.database.papers import get_authors_for_papers


### PR DESCRIPTION
## Summary
- **Richer publication cards**: Authors now show full first names with institution affiliations inline (e.g. "Ana Méndez (MIT) · Rachel Okafor (UC Berkeley)") — backend query updated to include `r.affiliation` from the researchers table
- **Fix clear-filters bug**: The "Clear filters" button was only visible when exactly 1 filter chip was active (`chips.length === 1`); now shows whenever any filters are active (`chips.length > 0`) on both the newsfeed and researchers pages
- **Dense researcher directory**: Rewrote `ResearcherCard` to a compact single-row layout — name + position/institution on the left, paper count + site link + follow button on the right — matching the redesign mockups

## Test plan
- [ ] Verify author names show full first names (not initials) on the feed
- [ ] Verify affiliations appear in parentheses next to author names on publication cards
- [ ] Apply 2+ filters on the newsfeed — confirm "Clear filters" button is visible
- [ ] Apply 2+ filters on the researchers page — confirm "Clear filters" button is visible
- [ ] Check researcher directory layout: name, position/institution, paper count, site link, follow all on one row
- [ ] Verify mobile layout wraps gracefully on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)