### PR TITLE
Fix FK violation on hide_event correction

### DIFF
--- a/backend/enrichment/quality_review.py
+++ b/backend/enrichment/quality_review.py
@@ -347,7 +347,10 @@ def review_events(batch_size: int = 100, dry_run: bool = False,
             high_issues = [x for x in issues if x.get("severity") == "high"]
 
             corrections = apply_corrections(event, review, dry_run=dry_run)
-            save_review(event["event_id"], review, corrections or None)
+            # hide_event deletes the feed_event row; skip saving (FK would fail)
+            has_hide = any(c.get("type") == "hide_event" for c in corrections)
+            if not has_hide:
+                save_review(event["event_id"], review, corrections or None)
 
             total_reviewed += 1
             total_issues += len(issues)

--- a/backend/enrichment/review_batch.py
+++ b/backend/enrichment/review_batch.py
@@ -194,7 +194,9 @@ def _process_completed_batch(client, batch, db_id: int) -> int:
             continue
 
         corrections = apply_corrections(event, review)
-        save_review(event_id, review, corrections or None)
+        has_hide = any(c.get("type") == "hide_event" for c in corrections)
+        if not has_hide:
+            save_review(event_id, review, corrections or None)
         processed += 1
 
         if corrections:


### PR DESCRIPTION
## Summary
- `apply_corrections` with `hide_event` DELETEs the `feed_events` row, then `save_review` tries to INSERT a review referencing that deleted event — FK constraint fails
- Skip saving reviews for hidden events (the event is gone anyway)
- Hit this during the 1000-event backfill on prod

## Test plan
- [ ] Re-run backfill after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)